### PR TITLE
added accessor for enumerating the dns_automation attribute of an accou...

### DIFF
--- a/mixcoatl/admin/account.py
+++ b/mixcoatl/admin/account.py
@@ -56,6 +56,11 @@ class Account(Resource):
         return self.__default_budget
 
     @lazy_property
+    def dns_automation(self):
+        """Does this account subscribe to dns_automation?"""
+        return self.__dns_automation
+
+    @lazy_property
     def name(self):
         """`str` - User-friendly name used to identify the account"""
         return self.__name


### PR DESCRIPTION
There was a problem that happened when enumerating accounts that had subscribed to dns_automation:

 'dns_automation': {'dns_zone_id': 50002, 'ttl': 3600},

The error is/was:

  File "/usr/local/bin/es-list-accounts", line 5, in <module>
    pkg_resources.run_script('enstratius-api-tools==0.1', 'es-list-accounts')
  File "/Library/Python/2.7/site-packages/distribute-0.6.28-py2.7.egg/pkg_resources.py", line 499, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/Library/Python/2.7/site-packages/distribute-0.6.28-py2.7.egg/pkg_resources.py", line 1239, in run_script
    execfile(script_filename, namespace, namespace)
  File "/Library/Python/2.7/site-packages/enstratius_api_tools-0.1-py2.7.egg/EGG-INFO/scripts/es-list-accounts", line 23, in <module>
    print a
  File "/Library/Python/2.7/site-packages/mixcoatl-0.2.6-py2.7.egg/mixcoatl/resource.py", line 94, in **repr**
    d[x] = getattr(self, x)
  File "/Library/Python/2.7/site-packages/mixcoatl-0.2.6-py2.7.egg/mixcoatl/decorators/lazy.py", line 51, in **get**
    raise LazyPropertyException(detail)
mixcoatl.decorators.lazy.LazyPropertyException: Key found without accessor: dns_automation
