### PR TITLE
added intersphinx mapping links

### DIFF
--- a/docs/mixcoatl.admin.rst
+++ b/docs/mixcoatl.admin.rst
@@ -1,5 +1,9 @@
+.. _mixcoatl_admin:
+
 admin Package
 =============
+
+.. _mixcoatl_admin_account:
 
 :mod:`account` Module
 ---------------------
@@ -9,6 +13,8 @@ admin Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_admin_api_key:
+
 :mod:`api_key` Module
 ---------------------
 
@@ -16,6 +22,8 @@ admin Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. _mixcoatl_admin_billing_code:
 
 :mod:`billing_code` Module
 --------------------------
@@ -25,6 +33,8 @@ admin Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_admin_group:
+
 :mod:`group` Module
 -------------------
 
@@ -32,6 +42,8 @@ admin Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. _mixcoatl_admin_job:
 
 :mod:`job` Module
 -----------------
@@ -41,6 +53,8 @@ admin Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_admin_role:
+
 :mod:`role` Module
 ------------------
 
@@ -48,6 +62,8 @@ admin Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. _mixcoatl_admin_user:
 
 :mod:`user` Module
 ------------------

--- a/docs/mixcoatl.analytics.rst
+++ b/docs/mixcoatl.analytics.rst
@@ -1,3 +1,5 @@
+.. _mixcoatl_analytics:
+
 analytics Package
 =================
 
@@ -9,6 +11,8 @@ analytics Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_analytics_server:
+
 :mod:`server_analytics` Module
 ------------------------------
 
@@ -16,6 +20,8 @@ analytics Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. _mixcoatl_analytics_tier:
 
 :mod:`tier_analytics` Module
 ----------------------------

--- a/docs/mixcoatl.automation.rst
+++ b/docs/mixcoatl.automation.rst
@@ -1,5 +1,9 @@
+.. _mixcoatl_automation:
+
 automation Package
 ==================
+
+.. _mixcoatl_automation_configuration_management_account:
 
 :mod:`configuration_management_account` Module
 ----------------------------------------------
@@ -9,6 +13,8 @@ automation Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_automation_deployment:
+
 :mod:`deployment` Module
 ------------------------
 
@@ -17,6 +23,8 @@ automation Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_automation_service:
+
 :mod:`service` Module
 ---------------------
 
@@ -24,6 +32,8 @@ automation Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. _mixcoatl_automation_tier:
 
 :mod:`tier` Module
 ------------------

--- a/docs/mixcoatl.config.rst
+++ b/docs/mixcoatl.config.rst
@@ -1,5 +1,9 @@
+.. _mixcoatl_package:
+
 config Package
 ==============
+
+.. _mixcoatl_package_config:
 
 :mod:`config` Package
 ---------------------

--- a/docs/mixcoatl.decorators.rst
+++ b/docs/mixcoatl.decorators.rst
@@ -1,3 +1,5 @@
+.. _mixcoatl_decorators:
+
 decorators Package
 ==================
 
@@ -9,6 +11,8 @@ decorators Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_decorators_lazy:
+
 :mod:`lazy` Module
 ------------------
 
@@ -16,6 +20,8 @@ decorators Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. _mixcoatl_decorators_validations:
 
 :mod:`validations` Module
 -------------------------

--- a/docs/mixcoatl.exceptions.rst
+++ b/docs/mixcoatl.exceptions.rst
@@ -1,3 +1,5 @@
+.. _mixcoatl_exceptions:
+
 exceptions Package
 ==================
 

--- a/docs/mixcoatl.geography.rst
+++ b/docs/mixcoatl.geography.rst
@@ -1,3 +1,5 @@
+.. _mixcoatl_geography:
+
 geography Package
 =================
 
@@ -9,6 +11,8 @@ geography Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_cloud:
+
 :mod:`cloud` Module
 -------------------
 
@@ -17,6 +21,8 @@ geography Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_datacenter:
+
 :mod:`datacenter` Module
 ------------------------
 
@@ -24,6 +30,8 @@ geography Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. _mixcoatl_region:
 
 :mod:`region` Module
 --------------------

--- a/docs/mixcoatl.infrastructure.rst
+++ b/docs/mixcoatl.infrastructure.rst
@@ -1,3 +1,5 @@
+.. _mixcoatl_infrastructure:
+
 infrastructure Package
 ======================
 
@@ -9,6 +11,8 @@ infrastructure Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_infrastructure_server:
+
 :mod:`server` Module
 --------------------
 
@@ -16,6 +20,8 @@ infrastructure Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. _mixcoatl_infrastructure_server_product:
 
 :mod:`server_product` Module
 ----------------------------
@@ -25,6 +31,8 @@ infrastructure Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_infrastructure_snapshot:
+
 :mod:`snapshot` Module
 ----------------------
 
@@ -32,6 +40,8 @@ infrastructure Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. _mixcoatl_infrastructure_volume:
 
 :mod:`volume` Module
 --------------------

--- a/docs/mixcoatl.network.rst
+++ b/docs/mixcoatl.network.rst
@@ -1,5 +1,9 @@
+.. _mixcoatl_network:
+
 network Package
 ===============
+
+.. _mixcoatl_network_firewall:
 
 :mod:`firewall` Module
 ----------------------
@@ -9,6 +13,8 @@ network Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_network_firewall_rule:
+
 :mod:`firewall_rule` Module
 ---------------------------
 
@@ -17,6 +23,8 @@ network Package
     :undoc-members:
     :show-inheritance:
 
+.. _mixcoatl_network_load_balancer:
+
 :mod:`load_balancer` Module
 ---------------------------
 
@@ -24,4 +32,3 @@ network Package
     :members:
     :undoc-members:
     :show-inheritance:
-

--- a/docs/mixcoatl.settings.rst
+++ b/docs/mixcoatl.settings.rst
@@ -1,5 +1,9 @@
+.. _mixcoatl_settings:
+
 settings Package
 ================
+
+.. _mixcoatl_settings_load_settings:
 
 :mod:`load_settings` Module
 ---------------------------


### PR DESCRIPTION
Need to be able to link the enstratius_api_tools documentation to the corresponding mixcoatl library components.
