### PR TITLE
added a requirement for submitting a budget code on server launch, even ...

### DIFF
--- a/mixcoatl/infrastructure/server.py
+++ b/mixcoatl/infrastructure/server.py
@@ -257,7 +257,7 @@ class Server(Resource):
     # this madness of returning the last error. Makes no sense. I should have
     # never done it.
     @required_attrs(['provider_product_id', 'machine_image', 'description',
-                    'name', 'data_center'])
+                    'name', 'data_center', 'budget'])
     def launch(self, callback=None):
         """Launches a server with the configured parameters
 
@@ -283,6 +283,7 @@ class Server(Resource):
         payload = {'launch':
                     [{
                         'productId': self.provider_product_id,
+                        'budget': self.budget,
                         'machineImage': camel_keys(self.machine_image),
                         'description': self.description,
                         'name': self.name,

--- a/tests/unit/infrastructure/test_server.py
+++ b/tests/unit/infrastructure/test_server.py
@@ -93,6 +93,7 @@ class TestServer(unittest.TestCase):
         s.description = 'unit test server'
         s.name = 'my-test-server'
         s.data_center = 64716
+        s.budget = 10287
         s.launch()
         assert s.last_error is None
         assert s.current_job == 84322
@@ -112,6 +113,7 @@ class TestServer(unittest.TestCase):
         s.description = 'unit test server'
         s.name = 'my-test-server'
         s.data_center = 64716
+        s.budget = 10287
         s.keypair = 'test-kp-uswest2'
         s.launch()
         assert s.keypair == 'test-kp-uswest2'


### PR DESCRIPTION
I lied. It _is_ required. We associate a budget code to any cloud resource that can incur a cost. In the U/I we apply 'default' to the launch if the user doesn't pick one. This budget value needs to be passed as part of a start server POST.
