### PR TITLE
Set the default DCM_ENDPOINT to dcm.enstratius.com

### DIFF
--- a/mixcoatl/config/__init__.py
+++ b/mixcoatl/config/__init__.py
@@ -127,7 +127,7 @@ class Config(object):
             if 'DCM_ENDPOINT' in os.environ:
                 self.set_endpoint(os.environ['DCM_ENDPOINT'])
             else:
-                self.set_endpoint('https://api.enstratus.com' + self.basepath)
+                self.set_endpoint('https://dcm.enstratius.com' + self.basepath)
 
         if self.ssl_verify is None:
             if 'ES_SSL_VERIFY' in os.environ and 'DCM_SSL_VERIFY' not in os.environ:


### PR DESCRIPTION
This is a patch on the 0.10.36 tag which sets the default DCM_ENDPOINT to a working URL. Thanks to @oldpatricka for dropping me the new URL.  This PR is against master, however I can obviously rebase if a 0.10.36 release branch is made.  