### PR TITLE
Add multiple endpoint support

### DIFF
--- a/bin/dcm-describe-server
+++ b/bin/dcm-describe-server
@@ -73,7 +73,7 @@ if __name__ == '__main__':
         if hasattr(s, 'owning_groups'):
             server_table.add_row(
                 ["Owning Group ID",
-                 s.owning_groups[0]['group_id'] if hasattr(s.owning_group[0],'group_id') else None])
+                 s.owning_groups[0]['group_id'] if hasattr(s.owning_groups[0],'group_id') else None])
             server_table.add_row(
                 ["Owning Group Name",
                  s.owning_groups[0]['name'] if hasattr(s.owning_groups[0],'name') else None])

--- a/mixcoatl/admin/account.py
+++ b/mixcoatl/admin/account.py
@@ -18,8 +18,8 @@ class Account(Resource):
     COLLECTION_NAME = 'accounts'
     PRIMARY_KEY = 'account_id'
 
-    def __init__(self, account_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, account_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__account_id = account_id
 
     @property
@@ -166,7 +166,7 @@ class Account(Resource):
             raise CreateAccountException(self.last_error)
 
     @classmethod
-    def all(cls, keys_only=False, **kwargs):
+    def all(cls, keys_only=False, endpoint=None, **kwargs):
         """Get all accounts
 
         >>> Account.all(detail='basic')
@@ -184,7 +184,7 @@ class Account(Resource):
         :returns: `list` of :class:`Account` or :attr:`account_id`
         :raises: :class:`AccountException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH,endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/admin/api_key.py
+++ b/mixcoatl/admin/api_key.py
@@ -18,8 +18,8 @@ class ApiKey(Resource):
     COLLECTION_NAME = 'apiKeys'
     PRIMARY_KEY = 'access_key'
 
-    def __init__(self, access_key=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, access_key=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__access_key = access_key
 
     @property
@@ -147,7 +147,7 @@ class ApiKey(Resource):
         return a
 
     @classmethod
-    def all(cls, keys_only=False, **kwargs):
+    def all(cls, keys_only=False, endpoint=None, **kwargs):
         """Get all api keys
 
         .. note::
@@ -166,10 +166,10 @@ class ApiKey(Resource):
         """
 
         if 'access_key' in kwargs:
-            r = Resource(cls.PATH + "/" + kwargs['access_key'])
+            r = Resource(cls.PATH + "/" + kwargs['access_key'], endpoint=endpoint)
             params = {}
         else:
-            r = Resource(cls.PATH)
+            r = Resource(cls.PATH, endpoint=endpoint)
 
             if 'detail' in kwargs:
                 r.request_details = kwargs['detail']

--- a/mixcoatl/admin/billing_code.py
+++ b/mixcoatl/admin/billing_code.py
@@ -19,8 +19,8 @@ class BillingCode(Resource):
     COLLECTION_NAME = 'billingCodes'
     PRIMARY_KEY = 'billing_code_id'
 
-    def __init__(self, billing_code_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, billing_code_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__billing_code_id = billing_code_id
 
     @property
@@ -99,7 +99,7 @@ class BillingCode(Resource):
         self.__soft_quota = s
 
     @classmethod
-    def all(cls, keys_only=False, **kwargs):
+    def all(cls, keys_only=False, endpoint=None, **kwargs):
         """Get all visible billing codes
 
         .. note::
@@ -113,7 +113,7 @@ class BillingCode(Resource):
         :returns: `list` - of :class:`BillingCode` or :attr:`billing_code_id`
         :raises: :class:`BillingCodeException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'details' in kwargs:

--- a/mixcoatl/admin/customer.py
+++ b/mixcoatl/admin/customer.py
@@ -19,8 +19,8 @@ class Customer(Resource):
     COLLECTION_NAME = 'customers'
     PRIMARY_KEY = 'customer_id'
 
-    def __init__(self, role_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, role_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__customer_id = customer_id
 
     @property
@@ -29,9 +29,9 @@ class Customer(Resource):
         return self.__customer_id
 
     @classmethod
-    def all(cls, keys_only=False, **kwargs):
+    def all(cls, keys_only=False, endpoint=None, **kwargs):
         """Get all customers"""
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/admin/group.py
+++ b/mixcoatl/admin/group.py
@@ -20,8 +20,8 @@ class Group(Resource):
     COLLECTION_NAME = 'groups'
     PRIMARY_KEY = 'group_id'
 
-    def __init__(self, group_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, group_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__group_id = group_id
 
     @property
@@ -90,7 +90,7 @@ class Group(Resource):
         return self.__role_assignments
 
     @classmethod
-    def all(cls, keys_only=False, **kwargs):
+    def all(cls, keys_only=False, endpoint=None, **kwargs):
         """Get all groups
 
         .. note::
@@ -106,7 +106,7 @@ class Group(Resource):
         :returns: `list` - List of :class:`Group` or :attr:`group_id`
         :raises: :class:`GroupException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/admin/job.py
+++ b/mixcoatl/admin/job.py
@@ -42,6 +42,14 @@ class Job(Resource):
         """`str` A message describing the current disposition of the operation"""
         return self.__message
 
+    def latest_message(self):
+        """`str` The *latest* message describing the current disposition of the operation
+            this method forces a reload of the Job attributes from the API. It is often useful
+            after waiting for a for a job to complete with wait_for(job_id)
+        """
+        self.load()
+        return self.message
+
     @lazy_property
     def start_date(self):
         """`str` The date and time when the job was started"""
@@ -79,7 +87,7 @@ class Job(Resource):
             raise JobException(r.last_error)
 
     @classmethod
-    def wait_for(cls, job_id, status='COMPLETE', callback=None):
+    def wait_for(cls, job_id, status='COMPLETE', callback=None, endpoint=None):
         """Blocks execution until :attr:`job_id` returns :attr:`status`
 
         :param job_id: The ID of the job to wait on
@@ -92,7 +100,7 @@ class Job(Resource):
         :returns: `bool` - Result of job exectution
         :raises: :class:`JobException`
         """
-        j = Job(job_id)
+        j = Job(job_id, endpoint=endpoint)
         j.load()
         if j.last_error is not None:
             raise JobException(j.last_error)

--- a/mixcoatl/admin/job.py
+++ b/mixcoatl/admin/job.py
@@ -18,8 +18,8 @@ class Job(Resource):
     COLLECTION_NAME = 'jobs'
     PRIMARY_KEY = 'job_id'
 
-    def __init__(self, job_id=None, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, job_id=None, endpoint=None, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__job_id = job_id
 
     @property
@@ -59,14 +59,14 @@ class Job(Resource):
         return self.__job_message
 
     @classmethod
-    def all(cls, keys_only=False):
+    def all(cls, keys_only=False, endpoint=None):
         """Get all jobs
         :param keys_only: Only return :attr:`job_id` instead of :class:`Job`
         :type keys_only: bool.
         :returns: `list` of :class:`Job` or :attr:`job_id`
         :raises: :class:`JobException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         x = r.get()
         if r.last_error is None:
             if keys_only is True:

--- a/mixcoatl/admin/role.py
+++ b/mixcoatl/admin/role.py
@@ -19,8 +19,8 @@ class Role(Resource):
     COLLECTION_NAME = 'roles'
     PRIMARY_KEY = 'role_id'
 
-    def __init__(self, role_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, role_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__role_id = role_id
 
     @property
@@ -92,7 +92,7 @@ class Role(Resource):
             raise RoleCreationException(self.last_error)
 
     @classmethod
-    def all(cls, keys_only=False, **kwargs):
+    def all(cls, keys_only=False, endpoint=None, **kwargs):
         """Get all roles
 
         .. note::

--- a/mixcoatl/admin/role.py
+++ b/mixcoatl/admin/role.py
@@ -110,7 +110,7 @@ class Role(Resource):
         :returns: `list` of :attr:`role_id` or :class:`Role`
         :raises: :class:`RoleException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/admin/user.py
+++ b/mixcoatl/admin/user.py
@@ -19,8 +19,8 @@ class User(Resource):
     COLLECTION_NAME = 'users'
     PRIMARY_KEY = 'user_id'
 
-    def __init__(self, user_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, user_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__user_id = user_id
 
     @property
@@ -252,7 +252,7 @@ class User(Resource):
             raise UserCreationException(self.last_error)
 
     @classmethod
-    def all(cls, keys_only=False, **kwargs):
+    def all(cls, keys_only=False, endpoint=None, **kwargs):
         """Return all users
 
         .. note::
@@ -266,7 +266,7 @@ class User(Resource):
         :returns: `list` of :class:`User` or :attr:`user_id`
         :raises: :class:`UserException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         if 'detail' in kwargs:
             r.request_details = kwargs['detail']
         else:

--- a/mixcoatl/analytics/server_analytics.py
+++ b/mixcoatl/analytics/server_analytics.py
@@ -65,7 +65,7 @@ class ServerAnalytics(Resource):
         return self.__interval_in_minutes
 
     @classmethod
-    def all(cls, server_id, keys_only=False, **kwargs):
+    def all(cls, server_id, keys_only=False, endpoint=None, **kwargs):
         """Get all analytics for `server_id`
 
         :param server_id: The server represented in the analytics
@@ -80,7 +80,7 @@ class ServerAnalytics(Resource):
         :param period_end: int.
         :returns: :class:`ServerAnalytics` or `list` of :attr:`data_points`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
         if 'detail' in kwargs:
             r.request_details = kwargs['detail']

--- a/mixcoatl/analytics/tier_analytics.py
+++ b/mixcoatl/analytics/tier_analytics.py
@@ -7,8 +7,8 @@ class TierAnalytics(Resource):
     COLLECTION_NAME = 'analytics'
     PRIMARY_KEY = 'tier_id'
 
-    def __init__(self, tier_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, tier_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__tier_id = tier_id
 
     @property
@@ -32,8 +32,8 @@ class TierAnalytics(Resource):
         return self.__interval_in_minutes
 
     @classmethod
-    def all(cls, tier_id, **kwargs):
-        r = Resource(cls.PATH+'/'+str(tier_id))
+    def all(cls, tier_id, endpoint=None, **kwargs):
+        r = Resource(cls.PATH+'/'+str(tier_id), endpoint=endpoint)
         if 'details' in kwargs:
             r.request_details = kwargs['details']
         else:

--- a/mixcoatl/auth.py
+++ b/mixcoatl/auth.py
@@ -5,16 +5,26 @@ import hmac
 from mixcoatl.settings.load_settings import settings
 
 
-def get_sig(http_method, path):
+def get_sig(http_method, path, endpoint=None):
     """Return a signature valid for use in making DCM API calls
 
     :param http_method: The `http_method` used to make the API call
     :param path: The `path` used in the API call
     """
+
+    if endpoint:
+        access_key = endpoint.access_key
+        secret_key = endpoint.secret_key
+        basepath = endpoint.basepath
+    else:
+        access_key = settings.access_key
+        secret_key = settings.secret_key
+        basepath = settings.basepath
+
     timestamp = int(round(time.time() * 1000))
-    signpath = settings.basepath + '/' + path
+    signpath = basepath + '/' + path
     parts = []
-    parts.append(settings.access_key)
+    parts.append(access_key)
     parts.append(http_method)
     parts.append(signpath)
     parts.append(timestamp)
@@ -22,9 +32,9 @@ def get_sig(http_method, path):
     # pylint: disable-msg=E1101
     dm = hashlib.sha256
     to_sign = ':'.join([str(x) for x in parts])
-    d = hmac.new(settings.secret_key, msg=to_sign, digestmod=dm).digest()
+    d = hmac.new(secret_key, msg=to_sign, digestmod=dm).digest()
     b64auth = base64.b64encode(d).decode()
     return {'timestamp': timestamp,
             'signature': b64auth,
-            'access_key': settings.access_key,
+            'access_key': access_key,
             'ua': settings.user_agent}

--- a/mixcoatl/automation/configuration_management_account.py
+++ b/mixcoatl/automation/configuration_management_account.py
@@ -12,8 +12,8 @@ class ConfigurationManagementAccount(Resource):
     COLLECTION_NAME = 'cmAccounts'
     PRIMARY_KEY = 'cm_account_id'
 
-    def __init__(self, cm_account_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, cm_account_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__cm_account_id = cm_account_id
 
     @property
@@ -77,8 +77,8 @@ class ConfigurationManagementAccount(Resource):
         return self.__owning_user
 
     @classmethod
-    def all(cls, **kwargs):
-        r = Resource(cls.PATH)
+    def all(cls, endpoint=None, **kwargs):
+        r = Resource(cls.PATH, endpoint=endpoint)
         if 'details' in kwargs:
             r.request_details = kwargs['details']
         else:

--- a/mixcoatl/automation/configuration_management_service.py
+++ b/mixcoatl/automation/configuration_management_service.py
@@ -15,8 +15,8 @@ class ConfigurationManagementService(Resource):
     COLLECTION_NAME = 'cmServices'
     PRIMARY_KEY = 'cm_system_id'
 
-    def __init__(self, cm_account_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, cm_account_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
 
     @lazy_property
     def cm_system(self):
@@ -91,8 +91,8 @@ class ConfigurationManagementService(Resource):
             raise CMCreationException(self.last_error)
 
     @classmethod
-    def all(cls, **kwargs):
-        r = Resource(cls.PATH)
+    def all(cls, endpoint=None, **kwargs):
+        r = Resource(cls.PATH, endpoint=endpoint)
 
         if 'details' in kwargs:
             r.request_details = kwargs['details']

--- a/mixcoatl/automation/configuration_management_system.py
+++ b/mixcoatl/automation/configuration_management_system.py
@@ -17,12 +17,12 @@ class ConfigurationManagementSystem(Resource):
     COLLECTION_NAME = 'cmSystems'
     PRIMARY_KEY = 'cm_system_id'
 
-    def __init__(self, cm_account_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, cm_account_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
 
     @classmethod
-    def all(cls, **kwargs):
-        r = Resource(cls.PATH)
+    def all(cls, endpoint=None, **kwargs):
+        r = Resource(cls.PATH, endpoint=endpoint)
 
         if 'details' in kwargs:
             r.request_details = kwargs['details']

--- a/mixcoatl/automation/environment.py
+++ b/mixcoatl/automation/environment.py
@@ -15,13 +15,13 @@ class Environment(Resource):
     COLLECTION_NAME = 'environments'
     PRIMARY_KEY = 'environmentId'
 
-    def __init__(self, environmentId=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, environmentId=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__environmentId = environmentId
 
     @classmethod
-    def all(cls, cmAccountId, **kwargs):
-        r = Resource(cls.PATH)
+    def all(cls, cmAccountId, endpoint=None, **kwargs):
+        r = Resource(cls.PATH, endpoint=endpoint)
 
         if 'detail' in kwargs:
             r.request_details = kwargs['detail']

--- a/mixcoatl/automation/personality.py
+++ b/mixcoatl/automation/personality.py
@@ -12,8 +12,8 @@ class Personality(Resource):
     COLLECTION_NAME = 'personalities'
     PRIMARY_KEY = 'cmAccountId'
 
-    def __init__(self, cmAccountId=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, cmAccountId=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__cmAccountId = cmAccountId
 
     @property
@@ -21,8 +21,8 @@ class Personality(Resource):
         return self.__cmAccountId
 
     @classmethod
-    def all(cls, cmAccountId, **kwargs):
-        r = Resource(cls.PATH)
+    def all(cls, cmAccountId, endpoint=None, **kwargs):
+        r = Resource(cls.PATH, endpoint=endpoint)
 
         if 'detail' in kwargs:
             r.request_details = kwargs['detail']

--- a/mixcoatl/automation/script.py
+++ b/mixcoatl/automation/script.py
@@ -15,8 +15,8 @@ class Script(Resource):
     COLLECTION_NAME = 'scripts'
     PRIMARY_KEY = 'cmAccountId'
 
-    def __init__(self, cmAccountId=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, cmAccountId=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__cmAccountId = cmAccountId
 
     @property
@@ -24,8 +24,8 @@ class Script(Resource):
         return self.__cmAccountId
 
     @classmethod
-    def all(cls, cmAccountId, **kwargs):
-        r = Resource(cls.PATH)
+    def all(cls, cmAccountId, endpoint=None, **kwargs):
+        r = Resource(cls.PATH, endpoint=endpoint)
 
         if 'detail' in kwargs:
             r.request_details = kwargs['detail']

--- a/mixcoatl/geography/cloud.py
+++ b/mixcoatl/geography/cloud.py
@@ -12,8 +12,8 @@ class Cloud(Resource):
     COLLECTION_NAME = 'clouds'
     PRIMARY_KEY = 'cloud_id'
 
-    def __init__(self, cloud_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, cloud_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__cloud_id = cloud_id
 
     @property
@@ -102,7 +102,7 @@ class Cloud(Resource):
         return self.__status
 
     @classmethod
-    def all(cls, keys_only=False, **kwargs):
+    def all(cls, keys_only=False, endpoint=None, **kwargs):
         """Return all clouds
 
         :param keys_only: Return :attr:`cloud_id` instead of :class:`Cloud`
@@ -111,7 +111,7 @@ class Cloud(Resource):
         :type detail: str.
         :returns: `list` of :class:`Cloud` or :attr:`cloud_id`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/geography/datacenter.py
+++ b/mixcoatl/geography/datacenter.py
@@ -14,8 +14,8 @@ class DataCenter(Resource):
     COLLECTION_NAME = 'dataCenters'
     PRIMARY_KEY = 'data_center_id'
 
-    def __init__(self, data_center_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, data_center_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__data_center_id = data_center_id
 
     @property
@@ -49,7 +49,7 @@ class DataCenter(Resource):
         return self.__status
 
     @classmethod
-    def all(cls, region_id, **kwargs):
+    def all(cls, region_id, endpoint=None, **kwargs):
         """Return all data centers
 
         :param region_id: Required. The region to query against
@@ -61,7 +61,7 @@ class DataCenter(Resource):
         :returns: `list` of :class:`DataCenter` or :attr:`data_center_id`
         :raises: :class:`DataCenterException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
 
         if 'detail' in kwargs:
             r.request_details = kwargs['detail']

--- a/mixcoatl/geography/region.py
+++ b/mixcoatl/geography/region.py
@@ -11,8 +11,8 @@ class Region(Resource):
     COLLECTION_NAME = 'regions'
     PRIMARY_KEY = 'region_id'
 
-    def __init__(self, region_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, region_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__region_id = region_id
 
     @property
@@ -56,7 +56,7 @@ class Region(Resource):
         return self.__description
 
     @classmethod
-    def all(cls, **kwargs):
+    def all(cls, endpoint=None, **kwargs):
         """Return all regions
 
         :param account_id: Limit results to regions with the specified account
@@ -73,7 +73,7 @@ class Region(Resource):
         :returns: `list` of :class:`Region` or :attr:`region_id`
         :raises: :class:`RegionException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/geography/subscription.py
+++ b/mixcoatl/geography/subscription.py
@@ -14,16 +14,16 @@ class Subscription(Resource):
     COLLECTION_NAME = 'subscriptions'
     PRIMARY_KEY = 'region_id'
 
-    def __init__(self, region_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, region_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__region_id = region_id
 
     @classmethod
-    def all(cls, keys_only=False, **kwargs):
+    def all(cls, keys_only=False,endpoint=None, **kwargs):
         if 'region_id' in kwargs:
-            r = Resource(cls.PATH + "/" + str(kwargs['region_id']))
+            r = Resource(cls.PATH + "/" + str(kwargs['region_id']), endpoint=endpoint)
         else:
-            r = Resource(cls.PATH)
+            r = Resource(cls.PATH, endpoint=endpoint)
 
         if 'details' in kwargs:
             r.request_details = kwargs['details']

--- a/mixcoatl/infrastructure/machine_image.py
+++ b/mixcoatl/infrastructure/machine_image.py
@@ -282,7 +282,7 @@ class MachineImage(Resource):
         return self.put(p, data=json.dumps(payload))
 
     @classmethod
-    def all(cls, **kwargs):
+    def all(cls, endpoint=None, **kwargs):
         """Return all machine images
 
         :param machine_image_id: The id of the machine image
@@ -301,9 +301,9 @@ class MachineImage(Resource):
         :raises: :class:`MachineImageException`
         """
         if 'machine_image_id' in kwargs:
-            r = Resource(cls.PATH + "/" + str(kwargs['machine_image_id']))
+            r = Resource(cls.PATH + "/" + str(kwargs['machine_image_id']), endpoint=endpoint)
         else:
-            r = Resource(cls.PATH)
+            r = Resource(cls.PATH, endpoint=endpoint)
 
         params = {}
 

--- a/mixcoatl/infrastructure/server.py
+++ b/mixcoatl/infrastructure/server.py
@@ -333,7 +333,7 @@ class Server(Resource):
             self.load()
         else:
             if Job.wait_for(self.current_job):
-                job = Job(self.current_job)
+                job = Job(self.current_job, endpoint=self.endpoint)
                 self.__server_id = job.message
                 self.load()
             else:

--- a/mixcoatl/infrastructure/server.py
+++ b/mixcoatl/infrastructure/server.py
@@ -510,6 +510,15 @@ class Server(Resource):
         else:
             raise ServerLaunchException(self.last_error)
 
+    def set_from_file(self, filename):
+        """load server attributes from a json file
+        :param filename: str with the full path to the json file containing the server attributes
+        """
+        server_file = open(filename).read()
+        server_dict = json.loads(server_file)
+        for key,value in server_dict.items():
+            setattr(self, key, value)
+
     def duplicate(self, server):
         pass
 

--- a/mixcoatl/infrastructure/server.py
+++ b/mixcoatl/infrastructure/server.py
@@ -15,9 +15,10 @@ class Server(Resource):
     COLLECTION_NAME = 'servers'
     PRIMARY_KEY = 'server_id'
 
-    def __init__(self, server_id=None):
-        Resource.__init__(self)
+    def __init__(self, server_id=None, endpoint=None):
+        Resource.__init__(self, endpoint=endpoint)
         self.__server_id = server_id
+
 
     @property
     def server_id(self):
@@ -540,7 +541,7 @@ class Server(Resource):
                 return self
 
     @classmethod
-    def all(cls, **kwargs):
+    def all(cls, endpoint=None, **kwargs):
         """Get a list of all known servers
 
         >>> Server.all()
@@ -549,7 +550,7 @@ class Server(Resource):
         :returns: list -- a list of :class:`Server`
         :raises: ServerException
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/infrastructure/server_product.py
+++ b/mixcoatl/infrastructure/server_product.py
@@ -13,8 +13,8 @@ class ServerProduct(Resource):
     COLLECTION_NAME = 'serverProducts'
     PRIMARY_KEY = 'product_id'
 
-    def __init__(self, product_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, product_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__product_id = product_id
 
     @property
@@ -93,7 +93,7 @@ class ServerProduct(Resource):
         return self.__software
 
     @classmethod
-    def all(cls, region_id, **kwargs):
+    def all(cls, region_id, endpoint=None, **kwargs):
         """Return all server products
 
         :param region_id: The region id to search in
@@ -105,7 +105,7 @@ class ServerProduct(Resource):
         :returns: `list` of :attr:`product_id` or :class:`ServerProduct`
         :raises: :class:`ServerProductException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         r.request_details = 'basic'
         params = {'regionId': region_id}
         if 'keys_only' in kwargs:

--- a/mixcoatl/infrastructure/snapshot.py
+++ b/mixcoatl/infrastructure/snapshot.py
@@ -275,7 +275,7 @@ class Snapshot(Resource):
             raise SnapshotException(r.last_error)
 
     @classmethod
-    def describe_snapshot(cls, snapshot_id, **kwargs):
+    def describe_snapshot(cls, snapshot_id, endpoint=None, **kwargs):
         """Changes the basic metadata for a snapshot
 
         :param id: The snapshot to modify
@@ -289,7 +289,7 @@ class Snapshot(Resource):
         :returns: :class:`Snapshot`
         :raises: :class:`SnapshotException`
         """
-        s = cls(snapshot_id)
+        s = cls(snapshot_id, endpoint=endpoint)
         for x in ['name', 'description', 'label']:
             if x in kwargs:
                 setattr(s, x, kwargs[x])
@@ -297,7 +297,7 @@ class Snapshot(Resource):
         return s
 
     @classmethod
-    def delete_snapshot(cls, snapshot_id, reason):
+    def delete_snapshot(cls, snapshot_id, reason, endpoint=None):
         """delete a snapshot
 
         :param snapshot_id: The DCM snapshot id
@@ -307,11 +307,11 @@ class Snapshot(Resource):
         :returns: `bool`
         :raises: :class:`SnapshotException`
         """
-        s = cls(snapshot_id)
+        s = cls(snapshot_id, endpoint=endpoint)
         return s.destroy(reason=reason)
 
     @classmethod
-    def add_snapshot(cls, volume_id, name, description, budget, callback=None):
+    def add_snapshot(cls, volume_id, name, description, budget, callback=None, endpoint=None):
         """Creates a snapshot from `volume_id`
 
             .. warning::
@@ -347,7 +347,7 @@ class Snapshot(Resource):
                 job = Job.wait_for(s.current_job)
                 if job is True:
                     try:
-                        j = Job(s.current_job)
+                        j = Job(s.current_job, endpoint=endpoint)
                         snapshot = cls(j.message)
                         snapshot.load()
                         callback(snapshot)

--- a/mixcoatl/infrastructure/snapshot.py
+++ b/mixcoatl/infrastructure/snapshot.py
@@ -14,9 +14,9 @@ class Snapshot(Resource):
     COLLECTION_NAME = 'snapshots'
     PRIMARY_KEY = 'snapshot_id'
 
-    def __init__(self, snapshot_id=None, *args, **kwargs):
+    def __init__(self, snapshot_id=None, endpoint=None, *args, **kwargs):
         # pylint: disable-msg=W0613
-        Resource.__init__(self)
+        Resource.__init__(self, endpoint=endpoint)
         self.__snapshot_id = snapshot_id
 
     @property
@@ -229,7 +229,7 @@ class Snapshot(Resource):
             raise SnapshotException(self.last_error)
 
     @classmethod
-    def all(cls, **kwargs):
+    def all(cls, endpoint=None, **kwargs):
         """Return a list of snapshots
 
         :param account_id: Restrict to snapshots owned by `account_id`
@@ -245,7 +245,7 @@ class Snapshot(Resource):
         :returns: `list` of :attr:`snapshot_id` or :class:`Snapshot`
         :raises: :class:`SnapshotException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/infrastructure/volume.py
+++ b/mixcoatl/infrastructure/volume.py
@@ -17,9 +17,9 @@ class Volume(Resource):
     COLLECTION_NAME = 'volumes'
     PRIMARY_KEY = 'volume_id'
 
-    def __init__(self, volume_id=None, **kwargs):
+    def __init__(self, volume_id=None, endpoint=None, **kwargs):
         # pylint: disable-msg=W0613
-        Resource.__init__(self)
+        Resource.__init__(self, endpoint=endpoint)
         if 'detail' in kwargs:
             self.request_details = kwargs['detail']
         self.__volume_id = volume_id
@@ -362,7 +362,7 @@ class Volume(Resource):
             raise VolumeSnapshotException(str(e))
 
     @classmethod
-    def all(cls, **kwargs):
+    def all(cls, endpoint=None, **kwargs):
         """List all volumes
         :param account_id: Restrict to volumes owned by `account_id`
         :type account_id: int.
@@ -377,7 +377,7 @@ class Volume(Resource):
         :returns: `list` of :attr:`volume_id` or :class:`Volume`
         :raises: :class:`VolumeException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/infrastructure/volume.py
+++ b/mixcoatl/infrastructure/volume.py
@@ -239,7 +239,7 @@ class Volume(Resource):
         payload = {'addVolume': [camel_keys(parms)]}
         self.post(data=json.dumps(payload))
         if self.last_error is None:
-            j = Job(self.current_job)
+            j = Job(self.current_job, endpoint=self.endpoint)
             j.load()
             if callback is not None:
                 callback(j)
@@ -366,7 +366,7 @@ class Volume(Resource):
                                          name,
                                          description,
                                          budget,
-                                         callback=callback)
+                                         callback=callback, endpoint=self.endpoint)
         except SnapshotException, e:
             raise VolumeSnapshotException(str(e))
 
@@ -416,17 +416,19 @@ class Volume(Resource):
             raise VolumeException(r.last_error)
 
     @classmethod
-    def assign_budget(cls, volume_id, budget):
+    def assign_budget(cls, volume_id, budget, endpoint=None):
         """Change the budget associated with a volume
 
         :param volume_id: The volume id to work with
         :type volume_id: int.
         :param budget: The budget code to assign
         :type budget: int.
+        :param endpoint: The DCM endpoint
+        :type endpoint: Endpoint
         :returns: `bool`
         :raises: :class:`VolumeException`
         """
-        v = Volume(volume_id)
+        v = Volume(volume_id, endpoint=endpoint)
         v.budget = budget
         return v.update()
 
@@ -444,7 +446,7 @@ class Volume(Resource):
         pass
 
     @classmethod
-    def attach_volume(cls, volume_id, server_id, device_id=None, callback=None):
+    def attach_volume(cls, volume_id, server_id, device_id=None, callback=None, endpoint=None):
         """Attach a volume to a server
 
             .. note::
@@ -459,19 +461,23 @@ class Volume(Resource):
         :type device_id: str.
         :param callback: Optional callback to call with the results
         :type callback: func.
+        :param endpoint: The DCM endpoint
+        :type endpoint: Endpoint
         :returns: :class:`Job`
         :raises: :class:`VolumeException`
         """
-        v = Volume(volume_id)
+        v = Volume(volume_id, endpoint=endpoint)
         v.request_details = 'basic'
         v.attach(server_id, device_id, callback)
 
     @classmethod
-    def describe_volume(cls, volume_id, **kwargs):
+    def describe_volume(cls, volume_id, endpoint=None, **kwargs):
         """Change the DCM meta-data of a volume
 
         :param volume_id: The volume to modify
         :type volume_id: int.
+        :param endpoint: The DCM endpoint
+        :type endpoint: Endpoint
         :param description: Change the description
         :type description: str.
         :param name: Change the name
@@ -484,7 +490,7 @@ class Volume(Resource):
         if kwargs is None:
             pass
         else:
-            v = Volume(volume_id)
+            v = Volume(volume_id, endpoint=endpoint)
             v.request_details = 'basic'
             for attr in kwargs:
                 setattr(v, attr, kwargs[attr])
@@ -492,7 +498,7 @@ class Volume(Resource):
             return v
 
     @classmethod
-    def add_volume(cls, **kwargs):
+    def add_volume(cls, endpoint=None, **kwargs):
         """Create a new volume
 
         :param name: The name of the new volume
@@ -501,10 +507,12 @@ class Volume(Resource):
         :param budget: The budget code for the new volume
         :param description: The description of the new volume
         :param callback: Optional callback to recieve the created Job
+        :param endpoint: The DCM endpoint
+        :type endpoint: Endpoint
         :returns: :class:`Job`
         :raises: :class:`VolumeCreationException`
         """
-        v = Volume()
+        v = Volume(endpoint=endpoint)
         cb = kwargs.pop('callback', None)
 
         for attr in kwargs:
@@ -513,12 +521,14 @@ class Volume(Resource):
         v.create(callback=cb)
 
     @classmethod
-    def detach_volume(cls, volume_id, callback=None):
+    def detach_volume(cls, volume_id, callback=None, endpoint=None):
         """Detach a volume from a server
 
         :param volume_id: The volume to detach
         :type volume_id: int.
         :param callback: Optional callback to send the results
+        :param endpoint: The DCM endpoint
+        :type endpoint: Endpoint
         :returns: :class:`Volume`
         :raises: :class:`VolumeException`
         """

--- a/mixcoatl/infrastructure/volume.py
+++ b/mixcoatl/infrastructure/volume.py
@@ -248,6 +248,15 @@ class Volume(Resource):
         else:
             raise VolumeCreationException(self.last_error)
 
+    def set_from_file(self, filename):
+        """load server attributes from a json file
+        :param filename: str with the full path to the json file containing the volume attributes
+        """
+        volume_file = open(filename).read()
+        volume_dict = json.loads(volume_file)
+        for key, value in volume_dict.items():
+            setattr(self, key, value)
+
     def update(self):
         """Updates a volume with changed values
 

--- a/mixcoatl/network/firewall.py
+++ b/mixcoatl/network/firewall.py
@@ -15,8 +15,8 @@ class Firewall(Resource):
     COLLECTION_NAME = 'firewalls'
     PRIMARY_KEY = "firewall_id"
 
-    def __init__(self, firewall_id=None, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, firewall_id=None, endpoint=None, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
 
         if 'detail' in kwargs:
             self.request_details = kwargs['detail']
@@ -179,7 +179,7 @@ class Firewall(Resource):
         """Describe a firewall"""
 
     @classmethod
-    def all(cls, **kwargs):
+    def all(cls, endpoint=None, **kwargs):
         """List all firewalls in `region_id`
         :param region_id: Limit results to `region_id`
         :type region_id: int.
@@ -192,7 +192,7 @@ class Firewall(Resource):
         :returns: `list` of :attr:`firewall_id` or :class:`Firewall`
         :raises: :class:`FirewallException`
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=None)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/network/firewall.py
+++ b/mixcoatl/network/firewall.py
@@ -166,7 +166,7 @@ class Firewall(Resource):
                 return self
             else:
                 if Job.wait_for(self.current_job) is True:
-                    j = Job(self.current_job)
+                    j = Job(self.current_job, endpoint=self.endpoint)
                     self.__firewall_id = j.message
                     self.load()
                     return self
@@ -222,7 +222,7 @@ class Firewall(Resource):
         else:
             raise FirewallException(r.last_error)
 
-    def describe_firewall(firewall_id, **kwargs):
+    def describe_firewall(firewall_id, endpoint=None, **kwargs):
         """Changes the basic meta-data for a firewall
 
         :param firewall_id: The id of the firewall to modify
@@ -238,7 +238,7 @@ class Firewall(Resource):
         """
 
         if kwargs:
-            f = Firewall(firewall_id)
+            f = Firewall(firewall_id, endpoint=endpoint)
             f.label = kwargs.get('label', None)
             f.description = kwargs.get('name', None)
             f.label = kwargs.get('label', None)

--- a/mixcoatl/network/firewall_rule.py
+++ b/mixcoatl/network/firewall_rule.py
@@ -14,11 +14,11 @@ class FirewallRule(Resource):
     COLLECTION_NAME = 'rules'
     PRIMARY_KEY = 'firewall_rule_id'
 
-    def __init__(self, firewall_rule_id=None, *args, **kwargs):
+    def __init__(self, firewall_rule_id=None, endpoint=None, *args, **kwargs):
         if 'detail' in kwargs:
             self.request_details = kwargs['detail']
 
-        Resource.__init__(self)
+        Resource.__init__(self, endpoint=endpoint)
         self.__firewall_rule_id = firewall_rule_id
 
     @property
@@ -174,7 +174,7 @@ class FirewallRule(Resource):
             raise FirewallRuleException(self.last_error)
 
     @classmethod
-    def all(cls, firewall_id, **kwargs):
+    def all(cls, firewall_id, endpoint=None, **kwargs):
         """List all rules for `firewall_id`
 
         :param firewall_id: The id of the firewall to list rules for
@@ -187,7 +187,7 @@ class FirewallRule(Resource):
         :raises: :class:`FirewallRuleException`
         """
 
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:

--- a/mixcoatl/network/load_balancer.py
+++ b/mixcoatl/network/load_balancer.py
@@ -13,8 +13,8 @@ class LoadBalancer(Resource):
     COLLECTION_NAME = 'loadBalancers'
     PRIMARY_KEY = 'load_balancer_id'
 
-    def __init__(self, load_balancer_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, load_balancer_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__load_balancer_id = load_balancer_id
 
     @property
@@ -86,8 +86,8 @@ class LoadBalancer(Resource):
         return self.__listeners
 
     @classmethod
-    def all(cls, **kwargs):
-        r = Resource(cls.PATH)
+    def all(cls, endpoint=None, **kwargs):
+        r = Resource(cls.PATH, endpoint=endpoint)
         if 'details' in kwargs:
             r.request_details = kwargs['details']
         else:

--- a/mixcoatl/network/network.py
+++ b/mixcoatl/network/network.py
@@ -20,8 +20,8 @@ class Network(Resource):
     COLLECTION_NAME = 'networks'
     PRIMARY_KEY = "network_id"
 
-    def __init__(self, network_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, network_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
 
         if 'detail' in kwargs:
             self.request_details = kwargs['detail']
@@ -267,7 +267,7 @@ class Network(Resource):
         return self.delete(p, params=qopts)
 
     @classmethod
-    def all(cls, **kwargs):
+    def all(cls, endpoint=None, **kwargs):
         """List all networks in `region_id`
 
         :param region_id: Limit results to `region_id`
@@ -286,7 +286,7 @@ class Network(Resource):
         :raises: :class:`NetworkException`
         """
         params = {}
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH,endpoint=endpoint)
 
         if 'detail' in kwargs:
             request_details = kwargs['detail']

--- a/mixcoatl/network/network.py
+++ b/mixcoatl/network/network.py
@@ -245,7 +245,7 @@ class Network(Resource):
         self.post(self.PATH, data=json.dumps(camel_keys(payload)))
 
         if self.last_error is None:
-            j = Job(self.current_job)
+            j = Job(self.current_job, endpoint=self.endpoint)
             j.load()
             if callback is not None:
                 callback(j)

--- a/mixcoatl/platform/relational_database.py
+++ b/mixcoatl/platform/relational_database.py
@@ -204,7 +204,7 @@ class RelationalDatabase(Resource):
             self.load()
         else:
             if Job.wait_for(self.current_job):
-                job = Job(self.current_job)
+                job = Job(self.current_job, endpoint=self.endpoint)
                 self.__relational_database_id = job.message
                 self.load()
             else:

--- a/mixcoatl/platform/relational_database.py
+++ b/mixcoatl/platform/relational_database.py
@@ -11,8 +11,8 @@ class RelationalDatabase(Resource):
     COLLECTION_NAME = 'relational_databases'
     PRIMARY_KEY = 'relational_database_id'
 
-    def __init__(self, relational_database_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, relational_database_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__relational_database_id = relational_database_id
 
     @property
@@ -312,8 +312,8 @@ class RelationalDatabase(Resource):
                 return self
 
     @classmethod
-    def all(cls, **kwargs):
-        r = Resource(cls.PATH)
+    def all(cls, endpoint=None, **kwargs):
+        r = Resource(cls.PATH,endpoint=endpoint)
         params = {}
         if 'detail' in kwargs:
             r.request_details = kwargs['detail']

--- a/mixcoatl/platform/relational_database_product.py
+++ b/mixcoatl/platform/relational_database_product.py
@@ -11,8 +11,8 @@ class RelationalDatabaseProduct(Resource):
     COLLECTION_NAME = 'rdbmsProducts'
     PRIMARY_KEY = 'product_id'
 
-    def __init__(self, product_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, product_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__product_id = product_id
 
     @property
@@ -130,7 +130,7 @@ class RelationalDatabaseProduct(Resource):
                 return self.last_error
 
     @classmethod
-    def all(cls, region_id, engine, **kwargs):
+    def all(cls, region_id, engine, endpoint=None, **kwargs):
         """Get a list of all known relational_databases
 
         >>> RelationalDatabaseProduct.all(region_id=100, engine='MYSQL51')
@@ -139,7 +139,7 @@ class RelationalDatabaseProduct(Resource):
         :returns: list -- a list of :class:`RelationalDatabaseProduct`
         :raises: RelationalDatabaseProductException
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         r.request_details = 'basic'
         params = {'regionId': region_id, 'engine': engine}
 

--- a/mixcoatl/platform/relational_database_product.py
+++ b/mixcoatl/platform/relational_database_product.py
@@ -123,7 +123,7 @@ class RelationalDatabaseProduct(Resource):
             self.load()
         else:
             if Job.wait_for(self.current_job):
-                job = Job(self.current_job)
+                job = Job(self.current_job, endpoint=self.endpoint)
                 self.__relational_database_id = job.message
                 self.load()
             else:

--- a/mixcoatl/platform/storage_object.py
+++ b/mixcoatl/platform/storage_object.py
@@ -10,8 +10,8 @@ class StorageObject(Resource):
     COLLECTION_NAME = 'storageObjects'
     PRIMARY_KEY = 'storage_object_id'
 
-    def __init__(self, storage_object_id=None, *args, **kwargs):
-        Resource.__init__(self)
+    def __init__(self, storage_object_id=None, endpoint=None, *args, **kwargs):
+        Resource.__init__(self, endpoint=endpoint)
         self.__storage_object_id = storage_object_id
 
     @property
@@ -139,7 +139,7 @@ class StorageObject(Resource):
                 return self.last_error
 
     @classmethod
-    def all(cls, region_id, **kwargs):
+    def all(cls, region_id, endpoint=None, **kwargs):
         """Get a list of all known storage objects.
 
         >>> StorageObject.all(region_id=100)
@@ -148,7 +148,7 @@ class StorageObject(Resource):
         :returns: list -- a list of :class:`StorageObject`
         :raises: StorageObjectException
         """
-        r = Resource(cls.PATH)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {'regionId': region_id}
 
         if 'detail' in kwargs:

--- a/mixcoatl/platform/storage_object.py
+++ b/mixcoatl/platform/storage_object.py
@@ -132,7 +132,7 @@ class StorageObject(Resource):
             self.load()
         else:
             if Job.wait_for(self.current_job):
-                job = Job(self.current_job)
+                job = Job(self.current_job, self.endpoint)
                 self.__storage_object_id = job.message
                 self.load()
             else:

--- a/mixcoatl/resource.py
+++ b/mixcoatl/resource.py
@@ -212,6 +212,10 @@ class Resource(object):
         return repr(convert(d))
 
     @property
+    def endpoint(self):
+        return self.__endpoint
+
+    @property
     def status_code(self):
         return self.__status_code
 

--- a/mixcoatl/resource.py
+++ b/mixcoatl/resource.py
@@ -10,11 +10,13 @@ from mixcoatl.decorators.lazy import lazy_property
 from mixcoatl.utils import camel_keys
 import json
 
+
 class Endpoint(object):
     """ A class for representing DCM endpoints and loading them from json files
     """
 
-    def __init__(self, url = None, basepath=None, api_version=None, secret_key=None, access_key=None, ssl_verify=True, nickname=None):
+    def __init__(self, url=None, basepath=None, api_version=None, secret_key=None,
+                 access_key=None, ssl_verify=True, nickname=None):
         """
         :param url: The url of the DCM endpoint (e.g https://dcm.enstratius.com/api/enstratus/2015-05-25 )
         :param basepath: Optional server path to the API (e.g. /api/enstratus/2015-05-25)
@@ -29,7 +31,7 @@ class Endpoint(object):
             self.url = url
         else:
             raise ValueError("endpoint must be specified")
-        if  api_version:
+        if api_version:
             self.api_version = api_version
         else:
             raise ValueError("api version must be specified")
@@ -50,7 +52,7 @@ class Endpoint(object):
         self.nickname = nickname
 
     @classmethod
-    def from_file(cls,filename):
+    def from_file(cls, filename):
         """ Load a DCM endpoint definition from a json file and return and Endpoint object. For an example file see:
             TODO: add github pointed to example file
 
@@ -62,14 +64,14 @@ class Endpoint(object):
 
         return Endpoint(url=e['url'],
                         basepath=e['basepath'] if 'basepath' in e else None,
-                        api_version= e['api_version'],
+                        api_version=e['api_version'],
                         secret_key=str(e['secret_key']),
                         access_key=str(e['access_key']),
                         ssl_verify=e['ssl_verify'] if 'ssl_verify' in e else None,
                         nickname=e['nickname'] if 'nickname' in e else None)
 
     @classmethod
-    def multiple_from_file(cls,filename):
+    def multiple_from_file(cls, filename):
         """ Load multiple DCM endpoint definitions from a json file and return a dictionary indexed by endpont nicknames
         For an example file see:
             TODO: add github pointed to example file
@@ -79,7 +81,7 @@ class Endpoint(object):
         """
         endpoint_json = open(filename).read()
         endpoint_in = json.loads(endpoint_json)
-        endpoint_dict ={}
+        endpoint_dict = {}
 
         for e in endpoint_in:
             endpoint_dict[e['nickname']] = Endpoint(url=e['url'],
@@ -89,8 +91,8 @@ class Endpoint(object):
                                                     access_key=str(e['access_key']),
                                                     ssl_verify=e['ssl_verify'] if 'ssl_verify' in e else None,
                                                     nickname=e['nickname'] if 'nickname' in e else None)
-
         return endpoint_dict
+
 
 class Resource(object):
 

--- a/tests/data/unit/admin/endpoint.json
+++ b/tests/data/unit/admin/endpoint.json
@@ -1,0 +1,8 @@
+{
+  "nickname":"saas",
+  "url":"https://dcm.enstratius.com/api/enstratus/2015-05-25",
+  "api_version":"2015-05-25",
+  "access_key":"abcdefg",
+  "secret_key":"gfedcba",
+  "ssl_verify": true
+}

--- a/tests/data/unit/admin/endpoints.json
+++ b/tests/data/unit/admin/endpoints.json
@@ -1,0 +1,18 @@
+[
+  {
+    "nickname": "saas",
+    "url": "https://dcm.enstratius.com/api/enstratus/2015-05-25",
+    "api_version": "2015-05-25",
+    "access_key": "abcdefg",
+    "secret_key": "gfedcba",
+    "ssl_verify": true
+  },
+  {
+    "nickname": "vagrant",
+    "url": "https://vagrant.vm/api/enstratus/2015-05-25",
+    "api_version": "2015-05-25",
+    "access_key": "abcdefg",
+    "secret_key": "gfedcba",
+    "ssl_verify": true
+  }
+]

--- a/tests/live/test_server.py
+++ b/tests/live/test_server.py
@@ -1,0 +1,48 @@
+import uuid
+
+from mixcoatl.resource import Endpoint
+from mixcoatl.infrastructure.server import Server
+from mixcoatl.admin.job import Job
+
+
+class TestServerLive:
+    def setup(self):
+        # load an endpoint that this file must be hosted outside of git
+        # because it contains credentials
+        self.endpoint = Endpoint.multiple_from_file("../../../secret-test-data/endpoints.json")['saas']
+
+    def test_saas_server_create(self):
+        """Test if we can create a VM using an live endpoint object and shut it down"""
+
+        # This cli command would make a server similar to below
+        # dcm-create-server --machineimage 29710 --datacenter 1273 \
+        #     --name igable-terminateme --productid t1.micro --budgetid 1512 --description longstring
+
+        self.server = Server(endpoint=self.endpoint)
+        self.server.set_from_file("../../../secret-test-data/ubuntu-trusty-14.04-amd64-server-20150629.json")
+
+        # override the server name loaded from the json
+        self.server.name = "mixcoatl-qa-%s" % str(uuid.uuid4())[:8]
+        self.job_id = self.server.launch()
+
+        Job.wait_for(self.job_id, endpoint=self.endpoint)
+        self.job = Job(job_id=str(self.job_id), endpoint=self.endpoint)
+
+        self.running_server = Server(self.job.message, endpoint=self.endpoint)
+        self.running_server.wait_for(status='RUNNING')
+
+        assert self.server.provider_product_id == self.running_server.provider_product_id
+        assert self.server.machine_image['machine_image_id'] == self.running_server.machine_image['machine_image_id']
+        assert self.server.data_center == self.running_server.data_center
+        assert self.server.description == self.running_server.description
+        assert self.server.name == self.running_server.name
+        assert self.server.budget == self.running_server.budget
+
+    def teardown(self):
+        if hasattr(self, 'running_server'):
+            if self.running_server:
+                try:
+                    assert self.running_server.destroy(reason="Mixcoatl QA test finished")
+                except AssertionError:
+                    raise AssertionError("Failed to destroy server id: %s with name: %s" %
+                                         (self.running_server.server_id, self.running_server.name))

--- a/tests/live/test_volume.py
+++ b/tests/live/test_volume.py
@@ -1,0 +1,43 @@
+import uuid
+
+from mixcoatl.resource import Endpoint
+from mixcoatl.infrastructure.volume import Volume
+from mixcoatl.admin.job import Job
+
+
+class TestVolumeLive:
+    def setup(self):
+        # load an endpoint that this file must be hosted outside of git
+        # because it contains credentials
+        self.endpoint = Endpoint.multiple_from_file("../../../secret-test-data/endpoints.json")['vagrant']
+
+    def test_volume_creation(self):
+        """Test the creating of a dummy volume against a live endpoint"""
+
+        # This command would create a volume similar to below
+        # dcm-create-volume --budgetid 1512 --datacenter 1273 --size 1 --name mixcoatl-qa --description junk
+
+        self.volume = Volume(endpoint=self.endpoint)
+        self.volume.set_from_file("../../../secret-test-data/vagrant-volume.json")
+        self.volume.name = "mixcoatl-qa-%s" % str(uuid.uuid4())[:8]
+        self.job = self.volume.create()
+        Job.wait_for(self.job.job_id, endpoint=self.endpoint)
+
+        # force reload of job attributed from DCM API
+        self.job.load()
+        self.live_volume = Volume(volume_id=self.job.message, endpoint=self.endpoint)
+
+        assert self.volume.data_center == self.live_volume.data_center
+        assert self.volume.budget == self.live_volume.budget
+        assert self.volume.size_in_gb == self.live_volume.size_in_gb
+        assert self.volume.description == self.live_volume.description
+        assert self.volume.name == self.live_volume.name
+
+    def teardown(self):
+        if hasattr(self, 'live_volume'):
+            if self.live_volume:
+                try:
+                    assert self.live_volume.destroy(reason="Mixcoatl QA test finished")
+                except AssertionError:
+                    raise AssertionError("Failed to destroy volume_id: %s with name: %s" %
+                                         (self.live_volume.volume_id, self.live_volume.name))

--- a/tests/unit/admin/test_endpoint.py
+++ b/tests/unit/admin/test_endpoint.py
@@ -1,0 +1,46 @@
+import sys
+# These have to be set before importing any mixcoatl modules
+import os
+os.environ['ES_ACCESS_KEY'] = 'abcdefg'
+os.environ['ES_SECRET_KEY'] = 'gfedcba'
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from mixcoatl.resource import Endpoint
+
+class TestEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        self.cls = Endpoint
+
+    def test_from_file(self):
+        '''test loading endpoint definitions from a json file'''
+
+        e = Endpoint.from_file("../../tests/data/unit/admin/endpoint.json")
+        assert e.nickname == "saas"
+        assert e.url == "https://dcm.enstratius.com/api/enstratus/2015-05-25"
+        assert e.api_version == "2015-05-25"
+        assert e.access_key == "abcdefg"
+        assert e.secret_key == "gfedcba"
+        assert e.ssl_verify == True
+
+    def test_multiple_from_file(self):
+        '''test loading multiple endpoints from file'''
+        e = Endpoint.multiple_from_file("../../tests/data/unit/admin/endpoints.json")
+        assert e['saas'].nickname == "saas"
+        assert e['saas'].url == "https://dcm.enstratius.com/api/enstratus/2015-05-25"
+        assert e['saas'].api_version == "2015-05-25"
+        assert e['saas'].access_key == "abcdefg"
+        assert e['saas'].secret_key == "gfedcba"
+        assert e['saas'].ssl_verify is True
+
+        assert e['vagrant'].nickname == "vagrant"
+        assert e['vagrant'].url == "https://vagrant.vm/api/enstratus/2015-05-25"
+        assert e['vagrant'].api_version == "2015-05-25"
+        assert e['vagrant'].access_key == "abcdefg"
+        assert e['vagrant'].secret_key == "gfedcba"
+        assert e['vagrant'].ssl_verify is True
+        


### PR DESCRIPTION
Add an Endpoint class as a part of the resource module. An Endpoint can be
optionally passed to any of the resource objects to allow them to
access a different DCM endpoint then the one specified either by
environment variables or in configuration files as loaded by the config
class.

- Issue #210 heavily inspired this feature, thanks @thijs-creemers
- Fixes Issue #207