### PR TITLE
Fix server reporting in dcm-lists-volumes, Fixes #226

### DIFF
--- a/bin/dcm-list-volumes
+++ b/bin/dcm-list-volumes
@@ -53,7 +53,7 @@ if __name__ == '__main__':
         table = PrettyTable(["Volume ID", "Provider ID", "Zone", "Name", "Server", "Size", "Owner", "Budget", "Status"])
         for r in results:
             if hasattr(r, 'server'):
-                server = r.server['server_id'] if hasattr(r.server, 'server_id') else 'Not Mounted'
+                server = r.server['server_id'] if 'server_id' in r.server else 'Not Mounted'
             else:
                 server = 'Not Mounted'
 


### PR DESCRIPTION
r.server is a dict, hasattr() won't work. 