### PR TITLE
Release/0.10.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+Mixcoatl ChangeLog
+==================
+
+Unreleased
+===========
+
+Release Date: pending
+
+You can now configure multiple alternate DCM endpoint via a new python object Endpoint.
+
+Features
+---------
+- Added #225: multiple endpoint support
+
+Fixes
+--------
+- Fixed #207: allow configuration via python
+
+0.10.50
+=============
+
+Release Date: 2015-07-01
+
+Features
+--------
+- Added #202: dcm-create-user support for ssh key
+- Added #214: support for ldap dirsync, saml config, private cloud pricing, and marketplace setup
+
+Fixes
+------
+- Fixed #217 #221:  some dcm-* cli tools crash when pretty printing missing attributes
+- Fixed #226: dcm-list-volumes not reporting server ID
+- Fix default DCM_ENDPOINT for dcm.enstratius.com
+- Automatically add missing resource properties
+
+
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 Mixcoatl ChangeLog
 ==================
 
+![Mixcoatl Snake](http://mixcoatl.net/assets/images/mixcoatl_serpent.png)
+
 Unreleased
 ===========
+Placeholder for changes pending in the next release
 
 Release Date: pending
 
@@ -10,28 +13,40 @@ You can now configure multiple alternate DCM endpoint via a new python object En
 
 Features
 ---------
-- Added #225: multiple endpoint support
+- Added [#225][225]: multiple endpoint support
 
 Fixes
 --------
-- Fixed #207: allow configuration via python
+- Fixed [#207][207]: allow configuration via python
+
+[207]:https://github.com/enStratus/mixcoatl/issues/207
+[225]:https://github.com/enStratus/mixcoatl/pull/225
 
 0.10.50
 =============
 
-Release Date: 2015-07-01
+Release Date: 2015-07-07
 
 Features
 --------
-- Added #202: dcm-create-user support for ssh key
-- Added #214: support for ldap dirsync, saml config, private cloud pricing, and marketplace setup
+- Added [#202][202]: dcm-create-user support for ssh key
+- Added [#214][214]: handsfree installer support for ldap dirsync, saml config, private cloud pricing, and marketplace setup
+- Added [#229][229]: runtime adding of access methods for new API attributes
 
 Fixes
 ------
-- Fixed #217 #221:  some dcm-* cli tools crash when pretty printing missing attributes
-- Fixed #226: dcm-list-volumes not reporting server ID
-- Fix default DCM_ENDPOINT for dcm.enstratius.com
-- Automatically add missing resource properties
+- Fixed [#217][217] [#221][221]:  some dcm-* cli tools crash when pretty printing missing attributes
+- Fixed [#226][226]: dcm-list-volumes not reporting server ID
+- Fixed [#212][212]: default DCM_ENDPOINT for dcm.enstratius.com
+
+[202]:https://github.com/enStratus/mixcoatl/pull/202
+[214]:https://github.com/enStratus/mixcoatl/pull/214
+[229]:https://github.com/enStratus/mixcoatl/issues/229
+[217]:https://github.com/enStratus/mixcoatl/pull/217
+[221]:https://github.com/enStratus/mixcoatl/issues/221
+[226]:https://github.com/enStratus/mixcoatl/issues/226
+[229]:https://github.com/enStratus/mixcoatl/issues/229
+[212]:https://github.com/enStratus/mixcoatl/pull/212
 
 
 

--- a/mixcoatl/__init__.py
+++ b/mixcoatl/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'mixcoatl'
-__version__ = '0.10.36'
+__version__ = '0.10.50'
 __author__ = 'Dell Cloud Manager Team'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2015, Dell Inc'

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import mixcoatl
 import os
 import glob
+import sys
 
 try:
     from setuptools import setup
@@ -25,6 +26,10 @@ packages = [
 ]
 
 requires = ['requests==1.0.4', 'prettytable==0.7.2', 'dicttoxml==1.5.8', 'termcolor==1.1.0', 'BeautifulSoup==3.2.1']
+
+if sys.version_info < (2, 7):
+    requires.append('argparse')
+
 setup(
     name='mixcoatl',
     version=mixcoatl.__version__,

--- a/tests/data/unit/admin/user-arbitrary.json
+++ b/tests/data/unit/admin/user-arbitrary.json
@@ -1,0 +1,52 @@
+{
+  "users": [
+    {
+      "alphaName": "Smith, Bob",
+      "customer": {
+        "customerId": 12345
+      }, 
+      "editable": false, 
+      "email": "bob.smith@domain.com", 
+      "familyName": "Smith", 
+      "givenName": "Bob", 
+      "groups": [
+        {
+          "groupId": 9465
+        }
+      ], 
+      "hasCloudAPIAccess": false, 
+      "hasCloudConsoleAccess": false, 
+      "status": "ACTIVE", 
+      "timeZone": "America/Chicago", 
+      "userId": 9876, 
+      "vmLoginId": "p9876"
+    }, 
+    {
+      "alphaName": "Vincent, John",
+      "favoriteColor":"Blue",
+      "quest": {
+        "name":"grail",
+        "ocupation":"knight"
+      },
+      "customer": {
+        "customerId": 12345
+      }, 
+      "editable": false, 
+      "email": "john.vincent@domain.com", 
+      "familyName": "Vincent", 
+      "givenName": "John", 
+      "groups": [
+        {
+          "groupId": 9465
+        }
+      ], 
+      "hasCloudAPIAccess": false, 
+      "hasCloudConsoleAccess": false, 
+      "status": "ACTIVE",
+      "sshPublicKey": "ssh-rsa AAAABsshkey user@machine",
+      "timeZone": "America/New_York", 
+      "userId": 6789, 
+      "vmLoginId": "p6789"
+    }
+  ]
+}

--- a/tests/unit/admin/test_user_arbitrary.py
+++ b/tests/unit/admin/test_user_arbitrary.py
@@ -1,0 +1,72 @@
+import os
+import sys
+# These have to be set before importing any mixcoatl modules
+os.environ['ES_ACCESS_KEY'] = 'abcdefg'
+os.environ['ES_SECRET_KEY'] = 'gfedcba'
+import json
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+from httpretty import HTTPretty
+from httpretty import httprettified
+
+import mixcoatl.admin.user as rsrc
+from mixcoatl.settings.load_settings import settings
+
+class TestUserArbitrary(unittest.TestCase):
+    def setUp(self):
+        self.cls = rsrc.User
+        self.es_url = '%s/%s' % (settings.endpoint, self.cls.PATH)
+        self.json_file = '../../tests/data/unit/admin/user-arbitrary.json'
+
+    @httprettified
+    def test_has_all_and_is_one(self):
+        '''test User.all() returns a list of User'''
+        with open(self.json_file) as f:
+            data = f.read()
+        HTTPretty.register_uri(HTTPretty.GET,
+            self.es_url,
+            body=data,
+            status=200,
+            content_type="application/json")
+
+        s = self.cls.all()
+        assert len(s) == 2
+
+    @httprettified
+    def test_has_one(self):
+        '''test User(<id>) returns a valid resource, and that we can handle arbitrary keys'''
+        pk = 6789
+        with open(self.json_file) as f:
+            data = json.load(f)
+        data[self.cls.COLLECTION_NAME][:] = [d for d in data[self.cls.COLLECTION_NAME] if d['userId'] == pk]
+        HTTPretty.register_uri(HTTPretty.GET,
+            self.es_url + '/' + str(pk),
+            body=json.dumps(data),
+            status=200,
+            content_type="application/json")
+        s = self.cls(pk)
+        assert s.user_id == pk
+        assert s.alpha_name == 'Vincent, John'
+
+        # check if can if the access methods for an arbitrary set of keys
+        # are created correctly are runtime
+        assert s.favorite_color == "Blue"
+        assert s.quest['name'] == "grail"
+
+        assert s.customer['customer_id'] == 12345
+        assert s.editable is False
+        assert s.email == 'john.vincent@domain.com'
+        assert s.family_name == 'Vincent'
+        assert s.given_name == 'John'
+        assert s.groups[0]['group_id'] == 9465
+        assert s.has_cloud_api_access is False
+        assert s.has_cloud_console_access is False
+        assert s.status == 'ACTIVE'
+        assert s.ssh_public_key == 'ssh-rsa AAAABsshkey user@machine'
+        assert s.time_zone == 'America/New_York'
+        assert s.user_id == 6789
+        assert s.vm_login_id == 'p6789'
+


### PR DESCRIPTION
This contains all the fixes since @igable started working on mixcoatl. I'm proposing we release this before any of the multiple endpoint stuff (#225) goes in. 

It's also important to note that this PR does not encompass all the changes since 0.10.36 since master was used as a integration branchfrom March to April. The full set of differences is [0.10.36...igable:release/0.10.50](https://github.com/enStratus/mixcoatl/compare/0.10.36...igable:release/0.10.50)

The vast majority of the changes relate to the handsfree install, however there are some could have the  potential for interference with existing users. If people have the time, it would be helpful to know the background:

- 4f693a1f1264fa2ca7a7b9 adding ssh keys to users, by @zomGreg. Did you have the opportunity to test?
- 351eb4b85b8e, a9d20a1, 08a231e, 7e1dca88f11 tweaks to the resource class, merged by @bdwilliams. Did you have the opportunity to test?
- Was anything from the head of master after the the 0.10.36 release widely deployed? 

Once I've come to grips with the testing infrastructure I will refrain from asking you if you tested some commit, and just ensure it's tested myself. Thanks in advance.

I've been using the above changes and running the nosetests against them for the last couple of weeks, and I haven't encountered any problems. 