### PR TITLE
Fix mixcoatl --version

### DIFF
--- a/bin/mixcoatl
+++ b/bin/mixcoatl
@@ -5,7 +5,7 @@ import json
 import urllib2
 import argparse
 import sys
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion,LooseVersion
 from mixcoatl import __version__
 
 
@@ -13,7 +13,7 @@ def versions(package_name):
     url = "https://pypi.python.org/pypi/%s/json" % (package_name,)
     data = json.load(urllib2.urlopen(urllib2.Request(url)))
     versions = data["releases"].keys()
-    versions.sort(key=StrictVersion)
+    versions.sort(key=LooseVersion)
     versions.reverse()
     return versions
 


### PR DESCRIPTION
Because 0.10.50.2 is not allowed by strick numbering if there is a 1.0.0
release we move temporarily to LooseVersion checking. Fix when I can
understand the consequences of removing 0.10.50.2 and .1 . Thanks to
Gary Forgetti for this.