### PR TITLE
Fixes #159 dcm-list-server-terminate

### DIFF
--- a/bin/dcm-list-server-terminate
+++ b/bin/dcm-list-server-terminate
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
-# Note: this tool is almost explicitly built for Iara releases.
+
 
 from mixcoatl.infrastructure.server import Server
 from prettytable import PrettyTable
 from datetime import datetime
-import argparse, sys
+import argparse
+import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -14,9 +15,9 @@ if __name__ == '__main__':
 
     if cmd_args.all or cmd_args.serverid:
         if cmd_args.serverid:
-            servers = [Server(cmd_args.serverid, detail='extended')]
+            servers = [Server(cmd_args.serverid)]
         else:
-            servers = Server.all(detail='extended')
+            servers = Server.all()
 
         server_table = PrettyTable(
             ["ID", "Cloud", "Region", "Provider ID", "Server Name", "Owner", "Status", "Termination"])
@@ -27,12 +28,9 @@ if __name__ == '__main__':
         for server in servers:
             if hasattr(server, 'owning_user'):
                 try:
-                    owning_user = server.owning_user['email']
+                    owning_user = server.owning_user['user_id']
                 except AttributeError:
-                    try:
-                        owning_user = server.owning_user['alpha_name']
-                    except AttributeError:
-                        owning_user = "Not Found"
+                    owning_user = "Not Found"
             else:
                 owning_user = "Not Found"
 
@@ -47,7 +45,8 @@ if __name__ == '__main__':
 
             server_table.add_row(
                 [server.server_id,
-                 server.cloud['cloud_provider_name'] if hasattr(server.cloud,'cloud_provider_name') else server.cloud['cloud_id'],
+                 server.cloud['cloud_provider_name'] if hasattr(server.cloud,
+                                                                'cloud_provider_name') else server.cloud['cloud_id'],
                  server.region['name'] if hasattr(server.region, 'name') else server.region['region_id'],
                  server.provider_id,
                  server.name,


### PR DESCRIPTION
terminateAfter is now available in basic DCM API response, hence
dcm-list-server-terminate can be fixed by no longer requiring the
extended attributes. Also some minor PEP8 changes to the script.