### PR TITLE
Remove BeautifulSoup dep, and loosen requirements

### DIFF
--- a/bin/dcm-list-api-versions
+++ b/bin/dcm-list-api-versions
@@ -1,36 +1,54 @@
 #!/usr/bin/env python
 
-import requests as r
-from mixcoatl import resource_utils, utils
-from prettytable import PrettyTable
-from BeautifulSoup import BeautifulSoup
-import time
-import sys
-import os
 
-def remove_duplicates(l):
-    return list(set(l))
+from mixcoatl import resource_utils, utils
+from mixcoatl.resource import Endpoint
+from mixcoatl.settings.load_settings import settings
+
+import argparse
+
 
 if __name__ == '__main__':
     """ List API Versions from DCM """
-    start = time.time()
-    url = os.environ['DCM_ENDPOINT'].split("/")
-    api_url = url[0]+"//"+url[2]+"/api/enstratus"
 
-    if os.environ['DCM_SSL_VERIFY'] == 1:
-        req = r.get(api_url)
+    endpoint = Endpoint(url=settings.endpoint,
+                           basepath=settings.basepath,
+                           api_version=settings.api_version,
+                           secret_key=settings.secret_key,
+                           access_key=settings.access_key,
+                           ssl_verify=settings.ssl_verify)
+
+    parser = argparse.ArgumentParser()
+
+    type_parser = parser.add_mutually_exclusive_group()
+    type_parser.add_argument('--active', '-a', action='store_true', help='Current active API version')
+    type_parser.add_argument('--latest', '-l', action='store_true',
+                             help='Latest version supported by the DCM endpoint')
+    type_parser.add_argument('--supported', '-s', action='store_true',
+                             help='Latest version supported by the DCM endpoint')
+
+    # add available output formats
+    utils.add_argparse_output_formats(parser.add_mutually_exclusive_group())
+
+    cmd_args = parser.parse_args()
+
+    thelist = []
+
+    if cmd_args.active:
+        thelist = [endpoint.api_version]
+    elif cmd_args.latest:
+        thelist = [endpoint.latest_api_version()]
     else:
-        req = r.get(api_url, verify=False)
+        # we default to all supported versions to keep with previous function of this command
+        thelist = endpoint.supported_api_versions()
 
-    versions = []
-    soup = BeautifulSoup(req.text)
-    find_all = soup.findAll('a')
+    if cmd_args.format:
+        if cmd_args.format == "xml" or cmd_args.format == "json":
+            print utils.format_dict(thelist, cmd_args.format)
+        if cmd_args.format == "csv":
+            for v in thelist:
+                print v
 
-    for v in find_all:
-        versions.append(v.text)
-
-    for v in sorted(remove_duplicates(versions), reverse=True):
-        print v
-
-    if 'DCM_DEBUG' in os.environ:
-        print 'Results returned in', time.time()-start, 'seconds.'
+    else:
+        for v in thelist:
+            print v

--- a/mixcoatl/utils.py
+++ b/mixcoatl/utils.py
@@ -1,5 +1,5 @@
 import json
-
+import xmltodict
 """Common helper utilities for use with mixcoatl"""
 
 def to_csv(data):
@@ -40,7 +40,7 @@ def print_format(data, payload_format):
     :param str payload_format: the the format that should be returned, either "json","xml","csv"
     :returns str: formatted string
     """
-    import dicttoxml
+
 
     newdata = []
     for i in data:
@@ -51,7 +51,9 @@ def print_format(data, payload_format):
         newdata.append(thedict)
 
     if payload_format == "xml":
-        return dicttoxml.dicttoxml(newdata)
+        return "%s %s %s"% ('<?xml version="1.0" ?><root>',
+                            xmltodict.unparse({"item":newdata}, full_document=False),
+                            '</root>')
     elif payload_format == "csv":
         return to_csv(newdata)
     else:
@@ -66,12 +68,13 @@ def format_dict(thedict, payload_format):
     :returns str: formatted string
     """
 
-    import dicttoxml
 
     if payload_format == "json":
         return json.dumps(thedict, indent=4, sort_keys=True)
     elif payload_format == "xml":
-        return dicttoxml.dicttoxml(thedict)
+        return "%s %s %s"% ('<?xml version="1.0" ?><root>',
+                            xmltodict.unparse({"item":thedict}, full_document=False),
+                            '</root>')
     elif payload_format == "csv":
         return to_csv([thedict])
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-requests==1.0.4
-nose==1.2.1
+requests>=1.0.4
+nose>=1.2.1
 pylint==0.26.0
 nosexcover==1.0.7
 mock==1.0.1
 httpretty==0.5.5
-prettytable==0.7.2
-termcolor==1.1.0
+prettytable>=0.7.2
+termcolor>=1.1.0
 sphinx_rtd_theme
 dicttoxml
-BeautifulSoup==3.2.1
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ prettytable>=0.7.2
 termcolor>=1.1.0
 sphinx_rtd_theme
 dicttoxml
-
+xmltodict>=0.4.2

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ packages = [
     'mixcoatl.settings'
 ]
 
-requires = ['requests>=1.0.4', 'prettytable==0.7.2', 'dicttoxml==1.5.8', 'termcolor==1.1.0', 'BeautifulSoup==3.2.1']
+requires = ['requests>=1.0.4', 'prettytable>=0.7.2', 'dicttoxml>=1.5.8']
 
 if sys.version_info < (2, 7):
     requires.append('argparse')

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ packages = [
     'mixcoatl.settings'
 ]
 
-requires = ['requests>=1.0.4', 'prettytable>=0.7.2', 'dicttoxml>=1.5.8']
+requires = ['requests>=1.0.4', 'prettytable>=0.7.2', 'xmltodict>=0.4.2']
 
 if sys.version_info < (2, 7):
     requires.append('argparse')


### PR DESCRIPTION
- Fixes #250 by allowing loading of newer request library
- Fixes #251 removing BeautifulSoup dep. Thanks @rwfaulkner for
  pointing out how to do this.
- Fixes #252 removing termcolor dep, can still use the handsfree by
  installing from requirements.txt

Note this **needs more testing** before it can be merged. But lets start looking at it.