### PR TITLE
Feature/cli docs fix

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,0 +1,11 @@
+requests>=1.0.4
+nose>=1.2.1
+pylint==0.26.0
+nosexcover==1.0.7
+mock==1.0.1
+httpretty==0.5.5
+prettytable>=0.7.2
+termcolor>=1.1.0
+sphinx_rtd_theme
+xmltodict>=0.4.2
+sphinxcontrib-programoutput

--- a/docs/cli_tools/cli_tools.rst
+++ b/docs/cli_tools/cli_tools.rst
@@ -26,6 +26,7 @@ DCM command line API tools.
    dcm-delete-volume
    dcm-describe-deployment
    dcm-describe-job
+   dcm-describe-license
    dcm-describe-machine-image
    dcm-describe-server
    dcm-detach-volume

--- a/docs/cli_tools/dcm-describe-license.rst
+++ b/docs/cli_tools/dcm-describe-license.rst
@@ -1,0 +1,21 @@
+.. raw:: latex
+  
+      \newpage
+
+.. _dcm_describe_license:
+
+dcm-describe-license
+--------------------
+
+
+Description
+~~~~~~~~~~~
+
+Returns licensing information for the present DCM instance. This information is only useful in the case of on-premsses
+deployments of DCM.
+
+Syntax
+~~~~~~
+
+.. program-output:: dcm-describe-license -h
+

--- a/docs/cli_tools/dcm-describe-license.rst
+++ b/docs/cli_tools/dcm-describe-license.rst
@@ -17,5 +17,24 @@ deployments of DCM.
 Syntax
 ~~~~~~
 
-.. program-output:: dcm-describe-license -h
+.. code-block:: bash
 
+    usage: dcm-describe-license [-h] [--json | --xml | --csv]
+
+    optional arguments:
+    -h, --help  show this help message and exit
+    --json      print API response in JSON format.
+    --xml       print API response in XML format.
+    --csv       print API response in CSV format.
+
+
+Output
+%%%%%%
+
+.. code-block:: bash
+
+    Licensee: Acme Corp
+    Days Until Expiration: 365
+    Expiration Date: 2016-06-18T16:07:21.311+0000
+    Server Limit: 200
+    License Valid: True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ from mixcoatl import __version__
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.intersphinx']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.intersphinx', 'sphinxcontrib.programoutput']
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:

--- a/docs/source/automation/deployment.rst
+++ b/docs/source/automation/deployment.rst
@@ -1,9 +1,0 @@
-.. _mixcoatl_automation_deployment:
-
-:mod:`deployment`
------------------
-
-.. automodule:: mixcoatl.automation.deployment
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/automation/service.rst
+++ b/docs/source/automation/service.rst
@@ -1,9 +1,0 @@
-.. _mixcoatl_automation_service:
-
-:mod:`service`
---------------
-
-.. automodule:: mixcoatl.automation.service
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/automation/tier.rst
+++ b/docs/source/automation/tier.rst
@@ -1,9 +1,0 @@
-.. _mixcoatl_automation_tier:
-
-:mod:`tier`
------------
-
-.. automodule:: mixcoatl.automation.tier
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/mixcoatl.automation.rst
+++ b/docs/source/mixcoatl.automation.rst
@@ -11,6 +11,3 @@ Mixcoatl Automation
    :titlesonly:
 
    automation/configuration_management_account
-   automation/deployment
-   automation/service
-   automation/tier

--- a/docs/source/mixcoatl/resource.rst
+++ b/docs/source/mixcoatl/resource.rst
@@ -1,5 +1,5 @@
 :class:`Resource`
----------------
+-----------------
 
 .. autoclass:: mixcoatl.resource.Resource
     :members:


### PR DESCRIPTION
Some changes to the CLI docs. We add dcm-describe-license. There is nice method available to to capture the help syntax using [sphinxcontrib-programoutput](https://pythonhosted.org/sphinxcontrib-programoutput/). Unfortunately I don't see a way to make that part work on read the docs, so this is disabled in this PR.