### PR TITLE
Feature/endpoint to firewall.all

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,22 @@ The CLI and Python library for interfacing with [Dell Cloud Manager](http://www.
 
 ![Mixcoatl Snake](http://mixcoatl.net/assets/images/mixcoatl_serpent.png)
 
+
+1.1.1
+=====
+
+Release Date 2015-08-10
+
+Use with DCM: 10.X, 11.X
+
+Primarily a documentation improvement release. Release not pushed to PyPI, but pushed to [ReadTheDocs.org][rtd].
+
+Fixes
+-----
+- [#260][260] Several documentation deficiencies
+
+[260]:https://github.com/enStratus/mixcoatl/pull/260
+
 1.1.0
 =====
 

--- a/mixcoatl/__init__.py
+++ b/mixcoatl/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'mixcoatl'
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 __author__ = 'Dell Cloud Manager Team'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2015, Dell Inc'

--- a/mixcoatl/network/firewall.py
+++ b/mixcoatl/network/firewall.py
@@ -192,7 +192,7 @@ class Firewall(Resource):
         :returns: `list` of :attr:`firewall_id` or :class:`Firewall`
         :raises: :class:`FirewallException`
         """
-        r = Resource(cls.PATH, endpoint=None)
+        r = Resource(cls.PATH, endpoint=endpoint)
         params = {}
 
         if 'detail' in kwargs:


### PR DESCRIPTION
The new endpoint structure was not threading through Firewall.all() properly.  This fixes that.