### PR TITLE
Fixes #265 dcm-create-account crash

### DIFF
--- a/bin/dcm-create-account
+++ b/bin/dcm-create-account
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 	parser = argparse.ArgumentParser()
 	parser.add_argument('--account_name', '-a', help='Account Name', required=True)
 	parser.add_argument('--cloud_id', '-c', help='Cloud ID', required=True)
-	#parser.add_argument('--customer', '-C', help='Customer ID')
+	parser.add_argument('--customer', '-C', help='Customer ID')
 	parser.add_argument('--account_number', '-n', help='Account Number', required=True)
 	parser.add_argument('--api_key', '-k', help='API Key', required=True)
 	parser.add_argument('--api_secret', '-s', help='API Secret Key', required=True)
@@ -22,7 +22,7 @@ if __name__ == '__main__':
 
 	a = Account()
 	a.account_name = cmd_args.account_name
-	#a.customer = cmd_args.customer
+	a.customer = cmd_args.customer
 	a.account_number = cmd_args.account_number.replace('\xc2\xa0', '')
 	a.cloud_id = cmd_args.cloud_id
 	a.api_key_id = cmd_args.api_key

--- a/mixcoatl/admin/account.py
+++ b/mixcoatl/admin/account.py
@@ -156,8 +156,9 @@ class Account(Resource):
             }
         ]}
 
-        if self.customer:
-            payload['addAccount'].append({'customer': {'customerId': int(self.customer)}})
+        if hasattr(self,'customer'):
+            if self.customer:
+                payload['addAccount'].append({'customer': {'customerId': int(self.customer)}})
 
         response = self.post(self.PATH, data=json.dumps(payload))
         if self.last_error is None:


### PR DESCRIPTION
Adding a new account had the potential to to access the accout property
customer without it being set. This needs more testing, but it's better
then the crash bug for now.