### PR TITLE
Fix #235 optional and required arguments

### DIFF
--- a/bin/dcm-assign-cloud
+++ b/bin/dcm-assign-cloud
@@ -6,11 +6,11 @@ import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--cloudid', '-c', help="DCM Cloud ID.")
-    parser.add_argument('--accountid', '-i', help="DCM Account ID.")
-    parser.add_argument('--accountnumber', '-n', help="Cloud credential's account number.")
-    parser.add_argument('--accesskey', '-a', help="Cloud credential's access key.")
-    parser.add_argument('--secretkey', '-s', help="Cloud credential's secrety key.")
+    parser.add_argument('--cloudid', '-c', help="DCM Cloud ID.", required=True)
+    parser.add_argument('--accountid', '-i', help="DCM Account ID.", required=True)
+    parser.add_argument('--accountnumber', '-n', help="Cloud credential's account number.", required=True)
+    parser.add_argument('--accesskey', '-a', help="Cloud credential's access key.", required=True)
+    parser.add_argument('--secretkey', '-s', help="Cloud credential's secrety key.", required=True)
 
     cmd_args = parser.parse_args()
 

--- a/bin/dcm-create-billing-code
+++ b/bin/dcm-create-billing-code
@@ -7,11 +7,11 @@ import sys
 if __name__ == '__main__':
     """ Create a billing code. """
     parser = argparse.ArgumentParser()
-    parser.add_argument('--name', '-n', help='Name')
-    parser.add_argument('--code', '-c', help='Budget Code')
-    parser.add_argument('--soft', help='Soft Quota')
-    parser.add_argument('--hard', help='Hard Quota')
-    parser.add_argument('--description', '-d', help='Description')
+    parser.add_argument('--name', '-n', help='Name', required=True)
+    parser.add_argument('--code', '-c', help='Budget Code', required=True)
+    parser.add_argument('--soft', help='Soft Quota', required=True)
+    parser.add_argument('--hard', help='Hard Quota', required=True)
+    parser.add_argument('--description', '-d', help='Description', required=True)
     cmd_args = parser.parse_args()
 
     if None in [cmd_args.name, cmd_args.code, cmd_args.soft, cmd_args.hard, cmd_args.description]:

--- a/bin/dcm-create-group
+++ b/bin/dcm-create-group
@@ -14,8 +14,8 @@ def print_verbose(name,gid):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--name', '-n', help='The name of the group.')
-    parser.add_argument('--description', '-d', help='The description of the group.')
+    parser.add_argument('--name', '-n', help='The name of the group.', required=True)
+    parser.add_argument('--description', '-d', help='The description of the group.', required=True)
     parser.add_argument('--verbose', '-v', action='store_true', default=False, help='Print out verbose information about the group creation.')
 
     cmd_args = parser.parse_args()

--- a/bin/dcm-create-network
+++ b/bin/dcm-create-network
@@ -6,11 +6,11 @@ import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--budgetid', '-b', help='Budget ID')
-    parser.add_argument('--name', '-n', help='Network Name')
-    parser.add_argument('--netaddress', '-a', help='Network address such as 192.168.0.0/24')
-    parser.add_argument('--regionid', '-r', help='Region ID')
-    parser.add_argument('--description', '-D', help='Description')
+    parser.add_argument('--budgetid', '-b', help='Budget ID', required=True)
+    parser.add_argument('--name', '-n', help='Network Name', required=True)
+    parser.add_argument('--netaddress', '-a', help='Network address such as 192.168.0.0/24', required=True)
+    parser.add_argument('--regionid', '-r', help='Region ID', required=True)
+    parser.add_argument('--description', '-D', help='Description', required=True)
     parser.add_argument('--dnsserver', '-d', help='DNS Server')
     parser.add_argument('--groupid', '-g', help='Owning Group ID')
 

--- a/bin/dcm-create-role
+++ b/bin/dcm-create-role
@@ -14,8 +14,8 @@ def print_verbose(name,rid):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--name', '-n', help='Role Name')
-    parser.add_argument('--description', '-d', help='Role Description')
+    parser.add_argument('--name', '-n', help='Role Name', required=True)
+    parser.add_argument('--description', '-d', help='Role Description', required=True)
     parser.add_argument('--verbose', '-v', action='store_true', default=False, help='Print out verbose information about the role creation.')
 
     cmd_args = parser.parse_args()

--- a/bin/dcm-create-server
+++ b/bin/dcm-create-server
@@ -7,11 +7,11 @@ import sys
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--productid', '-p', help="Provider's product ID such as m1.large")
-    parser.add_argument('--machineimage', '-m', help='Machine image ID')
-    parser.add_argument('--datacenter', '-d', help='Data Center ID')
-    parser.add_argument('--description', '-D', help='Description')
-    parser.add_argument('--name', '-n', help='Server Name')
+        '--productid', '-p', help="Provider's product ID such as m1.large", required=True)
+    parser.add_argument('--machineimage', '-m', help='Machine image ID', required=True)
+    parser.add_argument('--datacenter', '-d', help='Data Center ID', required=True)
+    parser.add_argument('--description', '-D', help='Description', required=True)
+    parser.add_argument('--name', '-n', help='Server Name', required=True)
     parser.add_argument('--budgetid', '-b', help='Budget ID')
     parser.add_argument('--keypair', '-k', help='Keypair Name')
     parser.add_argument('--vlan', '-v', help='VLAN, deprecated since DCM k.50 use --network')

--- a/bin/dcm-delete-billing-code
+++ b/bin/dcm-delete-billing-code
@@ -6,9 +6,9 @@ import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--billingcodeid', '-b', type=int, help='Billing Code ID')
-    parser.add_argument('--reason', '-r', help='The reason for deleting the billing code.')
-    parser.add_argument('--replacementcodeid', '-R', type=int, help='Replacement code ID.')
+    parser.add_argument('--billingcodeid', '-b', type=int, help='Billing Code ID', required=True)
+    parser.add_argument('--reason', '-r', help='The reason for deleting the billing code.', required=True)
+    parser.add_argument('--replacementcodeid', '-R', type=int, help='Replacement code ID.', required=True)
 
     cmd_args = parser.parse_args()
 

--- a/bin/dcm-delete-network
+++ b/bin/dcm-delete-network
@@ -6,7 +6,7 @@ import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--networkid', '-i', type=int, help='Network ID')
+    parser.add_argument('--networkid', '-i', type=int, help='Network ID', required=True)
     parser.add_argument('--reason', '-r', help='The reason for deleting the network.')
 
     cmd_args = parser.parse_args()

--- a/bin/dcm-detach-volume
+++ b/bin/dcm-detach-volume
@@ -8,7 +8,7 @@ import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--volumeid', '-v', type=int, required=True, help='Volume ID of the volume to be detached.')
+    parser.add_argument('--volumeid', '-v', type=int, required=True, help='Volume ID of the volume to be detached.', required=True)
 
     cmd_args = parser.parse_args()
 

--- a/bin/dcm-set-role
+++ b/bin/dcm-set-role
@@ -47,9 +47,9 @@ def set_all_accounts(group_id,role_id):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--group_id', '-g', type=int, help='Group ID')
-    parser.add_argument('--role_id', '-r', type=int, help='The role ID.')
-    parser.add_argument('--account_id', '-a', type=int, help='The role ID.')
+    parser.add_argument('--group_id', '-g', type=int, help='Group ID', required=True)
+    parser.add_argument('--role_id', '-r', type=int, help='The role ID.', required=True)
+    parser.add_argument('--account_id', '-a', type=int, help='The role ID.', required=True)
 
     cmd_args = parser.parse_args()
 

--- a/bin/dcm-set-server-terminate
+++ b/bin/dcm-set-server-terminate
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 
 from mixcoatl.infrastructure.server import Server

--- a/bin/dcm-start-server
+++ b/bin/dcm-start-server
@@ -6,7 +6,7 @@ import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--server_id', '-s', type=int, help='Server ID')
+    parser.add_argument('--server_id', '-s', type=int, help='Server ID', required=True)
     cmd_args = parser.parse_args()
 
     if cmd_args.server_id is None:

--- a/bin/dcm-stop-server
+++ b/bin/dcm-stop-server
@@ -8,7 +8,7 @@ import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--server_id', '-s', type=int, help='Server ID')
+    parser.add_argument('--server_id', '-s', type=int, help='Server ID', required=True)
     cmd_args = parser.parse_args()
 
     if cmd_args.server_id is None:

--- a/bin/dcm-terminate-server
+++ b/bin/dcm-terminate-server
@@ -6,7 +6,7 @@ import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--server_id', '-s', type=int, help='Server ID')
+    parser.add_argument('--server_id', '-s', type=int, help='Server ID', required=True)
     parser.add_argument('--reason', '-r', help='The reason for terminating the server.')
     cmd_args = parser.parse_args()
 

--- a/bin/dcm-update-group
+++ b/bin/dcm-update-group
@@ -27,8 +27,8 @@ if __name__ == '__main__':
     group = Group(gid)
 
     if group_description is None and group_name is not None:
-        result = group.updateName(group_name)
+        result = group.update_name(group_name)
     elif group_name is None and group_description is not None:
-        result = group.updateDescription(group_description)
+        result = group.update_description(group_description)
     else:
         result = group.update(group_name, group_description)

--- a/bin/dcm-update-group
+++ b/bin/dcm-update-group
@@ -9,25 +9,26 @@ import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--group_id', '-g', type=int, help='Group ID')
+    parser.add_argument('--group_id', '-g', type=int, help='Group ID', required=True)
     parser.add_argument('--name', '-n', help='The name of the group.')
     parser.add_argument('--description', '-d', help='The description of the group.')
 
     cmd_args = parser.parse_args()
 
-    if (cmd_args.group_id is None or (cmd_args.group_id is not None and (cmd_args.description is None and cmd_args.name is None))):
+    if not any([cmd_args.description, cmd_args.name]):
+        print "At least one of --name or --description must be provided."
         parser.print_help()
         sys.exit(1)
 
-    gid=cmd_args.group_id
-    group_name=cmd_args.name
-    group_description=cmd_args.description
+    gid = cmd_args.group_id
+    group_name = cmd_args.name
+    group_description = cmd_args.description
 
     group = Group(gid)
 
-    if (group_description is None and group_name is not None):
+    if group_description is None and group_name is not None:
         result = group.updateName(group_name)
-    elif (group_name is None and group_description is not None):
+    elif group_name is None and group_description is not None:
         result = group.updateDescription(group_description)
     else:
-        result = group.update(group_name,group_description)
+        result = group.update(group_name, group_description)


### PR DESCRIPTION
Set required=True for all the argparse arguments where appropriate. Note
that the required args were clarified in the modified logic in
dcm-update-group (with identical reseults).