### PR TITLE
Fix #286 dcm-list-server-products region id

### DIFF
--- a/bin/dcm-list-server-products
+++ b/bin/dcm-list-server-products
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from mixcoatl.infrastructure.server_product import ServerProduct
+from mixcoatl.geography.region import Region
 from mixcoatl import resource_utils, utils
 from prettytable import PrettyTable
 import os
@@ -8,26 +9,44 @@ import time
 import argparse
 import sys
 
+
+def lookup_region_id(provider_region_id):
+    regions = Region.all()
+    for r in regions:
+        if r.provider_id == provider_region_id:
+            return r.region_id
+    return None
+
+
 if __name__ == '__main__':
     """ List Server Products """
     start = time.time()
     parser = argparse.ArgumentParser()
-    parser.add_argument('--regionid', '-r', help='Region ID')
 
     group_two = parser.add_mutually_exclusive_group()
-    group_two.add_argument('--json', action='store_true',
+    group_two.add_argument('--regionid', '-r', type=int,
+                           help='show only results with the DCM REGIONID (use dcm-list-regions to find the IDs)')
+    group_two.add_argument('--provider-region-id', '-p',
+                           help='show only results with the provider PROVIDER_REGION_ID (for example us-east-1 )')
+
+    group_three = parser.add_mutually_exclusive_group()
+    group_three.add_argument('--json', action='store_true',
         help='print API response in JSON format.')
-    group_two.add_argument('--xml', action='store_true',
+    group_three.add_argument('--xml', action='store_true',
         help='print API response in XML format.')
-    group_two.add_argument('--csv', action='store_true',
+    group_three.add_argument('--csv', action='store_true',
         help='print API response in XML format.')
     cmd_args = parser.parse_args()
 
-    if cmd_args.regionid != None:
-        results = ServerProduct.all(cmd_args.regionid)
+    if cmd_args.provider_region_id is not None:
+        region_id = lookup_region_id(cmd_args.provider_region_id)
+        if region_id is None:
+            print "Provider region id: %s not found" % cmd_args.provider_region_id
+            sys.exit(1)
     else:
-        parser.print_help()
-        sys.exit(1)
+        region_id = cmd_args.regionid
+
+    results = ServerProduct.all(region_id)
 
     if cmd_args.xml is True or cmd_args.json is True or cmd_args.csv is True:
         if cmd_args.xml is True:

--- a/bin/dcm-list-server-products
+++ b/bin/dcm-list-server-products
@@ -26,8 +26,8 @@ if __name__ == '__main__':
     group_two = parser.add_mutually_exclusive_group()
     group_two.add_argument('--regionid', '-r', type=int,
                            help='show only results with the DCM REGIONID (use dcm-list-regions to find the IDs)')
-    group_two.add_argument('--provider-region-id', '-p',
-                           help='show only results with the provider PROVIDER_REGION_ID (for example us-east-1 )')
+    group_two.add_argument('--regionpid', '-p',
+                           help='show only results with the provider REGIONPID (for example us-east-1 )')
 
     group_three = parser.add_mutually_exclusive_group()
     group_three.add_argument('--json', action='store_true',
@@ -38,10 +38,10 @@ if __name__ == '__main__':
         help='print API response in XML format.')
     cmd_args = parser.parse_args()
 
-    if cmd_args.provider_region_id is not None:
-        region_id = lookup_region_id(cmd_args.provider_region_id)
+    if cmd_args.regionpid is not None:
+        region_id = lookup_region_id(cmd_args.regionpid)
         if region_id is None:
-            print "Provider region id: %s not found" % cmd_args.provider_region_id
+            print "Provider region id: %s not found" % cmd_args.regionpid
             sys.exit(1)
     else:
         region_id = cmd_args.regionid

--- a/bin/dcm-list-server-products
+++ b/bin/dcm-list-server-products
@@ -58,13 +58,14 @@ if __name__ == '__main__':
 
         print utils.print_format(results, payload_format)
     else:
-        table = PrettyTable(["Server Product ID", "Provider Region ID", "Provider Product ID", "Name", "Platform", "Currency", "Hourly Rate"])
+        table = PrettyTable(["Server Product ID", "Provider Region ID", "Provider Product ID", "Name", "Arch", "Platform", "Currency", "Hourly Rate"])
         for r in results:
             table.add_row([
                 r.product_id,
                 r.provider_region_id,
                 r.provider_product_id,
                 r.name,
+                r.architecture,
                 r.platform,
                 r.currency,
                 r.hourly_rate])

--- a/docs/cli_tools/dcm-list-server-products.rst
+++ b/docs/cli_tools/dcm-list-server-products.rst
@@ -12,39 +12,59 @@ List server products for a region.
 Description
 ~~~~~~~~~~~
 
-Returns server products for a given cloud region. A :ref:`region ID <dcm_list_regions>` is required.
+Returns available server products. You can filter the list of products by :ref:`region ID <dcm_list_regions>` and
+by :ref:`provider region ID <dcm_list_regions>`.
 
 Syntax
 ~~~~~~
 
 .. code-block:: bash
 
-   usage: dcm-list-server-products [-h] [--regionid REGIONID] [--verbose]
+   usage: dcm-list-server-products [-h]
+                                   [--regionid REGIONID | --provider-region-id PROVIDER_REGION_ID]
+                                   [--json | --xml | --csv]
 
    optional arguments:
      -h, --help            show this help message and exit
      --regionid REGIONID, -r REGIONID
-                           Region ID
-     --verbose, -v         Produce verbose output
+                           show only results with the DCM REGIONID (use dcm-list-
+                           regions to find the IDs)
+     --provider-region-id PROVIDER_REGION_ID, -p PROVIDER_REGION_ID
+                           show only results with the provider PROVIDER_REGION_ID
+                           (for example us-east-1 )
+     --json                print API response in JSON format.
+     --xml                 print API response in XML format.
+     --csv                 print API response in XML format.
 
 Options
 ~~~~~~~
 
-+--------------------+------------------------------------------------------------+
-| Option             | Description                                                |
-+====================+============================================================+
-| -r, --regionid     | The region for which server products will be listed        | 
-|                    |                                                            |
-|                    | Type: String/Integer                                       |
-|                    |                                                            |
-|                    | Default: None                                              |
-|                    |                                                            |
-|                    | Required: Yes                                              |
-|                    |                                                            |
-|                    | Example: 1403                                              |
-+--------------------+------------------------------------------------------------+
-| -v, --verbose      | Print out verbose information while listing regions        |
-+--------------------+------------------------------------------------------------+
++-------------------------+-------------------------------------------------------+
+| Option                  | Description                                           |
++=========================+=======================================================+
+| -r, --regionid          | The region for which server products will be listed   |
+|                         |                                                       |
+|                         | Type: String/Integer                                  |
+|                         |                                                       |
+|                         | Default: None                                         |
+|                         |                                                       |
+|                         | Required: No                                          |
+|                         |                                                       |
+|                         | Example: 1403                                         |
++-------------------------+-------------------------------------------------------+
+|-p, --provider-region-id | The provider product id which server products will be |
+|                         | listed.                                               |
+|                         |                                                       |
+|                         | Type: String/Integer                                  |
+|                         |                                                       |
+|                         | Default: None                                         |
+|                         |                                                       |
+|                         | Required: No                                          |
+|                         |                                                       |
+|                         | Example: us-east-1                                    |
++-------------------------+-------------------------------------------------------+
+| -v, --verbose           | Print out verbose information while listing regions   |
++-------------------------+-------------------------------------------------------+
 
 Common Options
 ~~~~~~~~~~~~~~
@@ -67,18 +87,37 @@ Example 1
 
 .. code-block:: bash
 
-   dcm-list-server-products -r RegionOne
+   dcm-list-server-products --provider-region-id us-east-1
 
 Output
 %%%%%%
 
 .. code-block:: bash
 
-   +-------------------+--------------------+---------------------+-----------+----------+----------+-------------+
-   | Server Product ID | Provider Region ID | Provider Product ID | Name      | Platform | Currency | Hourly Rate |
-   +-------------------+--------------------+---------------------+-----------+----------+----------+-------------+
-   | 10000             | RegionOne          | 6                   | m1.custom | UNIX     | USD      | 0.14        |
-   +-------------------+--------------------+---------------------+-----------+----------+----------+-------------+
+   +-------------------+--------------------+---------------------+----------------------+----------+----------+-------------+
+   | Server Product ID | Provider Region ID | Provider Product ID | Name                 | Platform | Currency | Hourly Rate |
+   +-------------------+--------------------+---------------------+----------------------+----------+----------+-------------+
+   | 2052              | us-east-1          | c1.medium           | c1.medium            | SUSE     | USD      | 0.23        |
+   | 2053              | us-east-1          | c1.medium           | c1.medium            | SUSE     | USD      | 0.23        |
+   | 1452              | us-east-1          | c1.medium           | c1.medium            | RHEL     | USD      | 0.19        |
+   | 1453              | us-east-1          | c1.medium           | c1.medium            | RHEL     | USD      | 0.19        |
+   | 3039              | us-east-1          | c1.medium           | c1.medium            | UNIX     | USD      | 0.13        |
+   | 3040              | us-east-1          | c1.medium           | High-CPU Medium      | UNKNOWN  | USD      | 0.145       |
+   | 3041              | us-east-1          | c1.medium           | c1.medium            | UNIX     | USD      | 0.13        |
+   | 3042              | us-east-1          | c1.medium           | High-CPU Medium      | UNKNOWN  | USD      | 0.145       |
+   | 3043              | us-east-1          | c1.medium           | c1.medium            | WINDOWS  | USD      | 0.21        |
+   | 3044              | us-east-1          | c1.medium           | c1.medium            | WINDOWS  | USD      | 0.21        |
+   | 2055              | us-east-1          | c1.xlarge           | c1.xlarge            | SUSE     | USD      | 0.62        |
+   | 1455              | us-east-1          | c1.xlarge           | c1.xlarge            | RHEL     | USD      | 0.65        |
+   | 3045              | us-east-1          | c1.xlarge           | c1.xlarge            | UNIX     | USD      | 0.52        |
+   | 3046              | us-east-1          | c1.xlarge           | High-CPU Extra Large | UNKNOWN  | USD      | 0.58        |
+   | 3047              | us-east-1          | c1.xlarge           | c1.xlarge            | WINDOWS  | USD      | 0.84        |
+   | 523               | us-east-1          | c3.2xlarge          | c3.2xlarge           | UNKNOWN  | USD      | 0.42        |
+   | 2317              | us-east-1          | c3.2xlarge          | c3.2xlarge           | WINDOWS  | USD      | 0.752       |
+   | 1119              | us-east-1          | c3.2xlarge          | c3.2xlarge           | RHEL     | USD      | 0.55        |
+   | 1719              | us-east-1          | c3.2xlarge          | c3.2xlarge           | SUSE     | USD      | 0.52        |
+   +-------------------+--------------------+---------------------+----------------------+----------+----------+-------------+
+
 
 Example 2
 ^^^^^^^^^

--- a/docs/cli_tools/dcm-list-server-products.rst
+++ b/docs/cli_tools/dcm-list-server-products.rst
@@ -21,7 +21,7 @@ Syntax
 .. code-block:: bash
 
    usage: dcm-list-server-products [-h]
-                                   [--regionid REGIONID | --provider-region-id PROVIDER_REGION_ID]
+                                   [--regionid REGIONID | --regionpid REGIONPID]
                                    [--json | --xml | --csv]
 
    optional arguments:
@@ -29,7 +29,7 @@ Syntax
      --regionid REGIONID, -r REGIONID
                            show only results with the DCM REGIONID (use dcm-list-
                            regions to find the IDs)
-     --provider-region-id PROVIDER_REGION_ID, -p PROVIDER_REGION_ID
+     --regionpid REGIONPID, -p REGIONPID
                            show only results with the provider PROVIDER_REGION_ID
                            (for example us-east-1 )
      --json                print API response in JSON format.
@@ -52,7 +52,7 @@ Options
 |                         |                                                       |
 |                         | Example: 1403                                         |
 +-------------------------+-------------------------------------------------------+
-|-p, --provider-region-id | The provider product id which server products will be |
+|-p, --regionpid          | The provider product id which server products will be |
 |                         | listed.                                               |
 |                         |                                                       |
 |                         | Type: String/Integer                                  |
@@ -87,7 +87,7 @@ Example 1
 
 .. code-block:: bash
 
-   dcm-list-server-products --provider-region-id us-east-1
+   dcm-list-server-products --regionpid us-east-1
 
 Output
 %%%%%%

--- a/tests/live/test_cli.py
+++ b/tests/live/test_cli.py
@@ -31,7 +31,6 @@ class TestCli:
             "dcm-list-networks",  # You must specify either a dataCenterId, regionId, or accountId
             "dcm-list-rdbms-products",  # argument --region/-r is required
             "dcm-list-server-analytics",  # --server SERVER (also no shown as required)
-            "dcm-list-server-products",  # --regionid REGIONID
             "dcm-list-server-terminate",  # required flag --all (change de default)
             "dcm-list-storage-objects",  # --regionid/-r is required
         ]


### PR DESCRIPTION
The --regionid flag was confusing, requiring the DCM regionid rather then
the provider region id as a user would expect. To maintain backwards
compatibility --region remains the same but a new --provider-region-id
flag is which takes input like 'us-east-1'. --regionid is also
no longer a required flag.