### PR TITLE
Fix #292 add columns to the dcm-list-servers

### DIFF
--- a/bin/dcm-list-servers
+++ b/bin/dcm-list-servers
@@ -5,7 +5,6 @@ from mixcoatl import resource_utils, utils
 from prettytable import PrettyTable
 import argparse
 import time
-import sys
 import os
 
 if __name__ == '__main__':
@@ -13,6 +12,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--region', '-r', help='Region ID')
     parser.add_argument('--extended', '-e', help='Extended Status')
+    parser.add_argument('--verbose', '-v', action='store_true', help='print more more Server properties in the table')
 
     user_args = parser.add_mutually_exclusive_group()
     user_args.add_argument("--userid", "-u", help="Owning user's VM login ID. For example, p100.")
@@ -64,30 +64,86 @@ if __name__ == '__main__':
         print utils.print_format(results, payload_format)
     else:
         if len(results) > 0:
-            table = PrettyTable(["Server ID", "Region", "Provider ID", "Server Name", "Public IP", "Platform", "Budget",
-                                 "Product", "Status", "Start Date"])
-            for r in results:
-                if hasattr(r, 'public_ip_address'):
-                    public_ip_address = r.public_ip_address
-                elif hasattr(r, 'public_ip_addresses'):
-                    public_ip_address = ",".join(r.public_ip_addresses)
-                else:
-                    public_ip_address = None
+            if cmd_args.verbose is True:
 
-                table.add_row([r.server_id,
-                               r.region['name'] if hasattr(r.region, 'name') else r.region['region_id'],
-                               r.provider_id if hasattr(r,'provider') else None,
-                               r.name if hasattr(r,'name') else None,
-                               public_ip_address,
-                               r.platform if hasattr(r,'platform') else None,
-                               r.budget if hasattr(r,'budget') else None,
-                               r.provider_product_id if hasattr(r,'provider_product_id') else None,
-                               r.status if hasattr(r,'status') else None,
-                               r.start_date if hasattr(r,'start_date') else None])
-            table.align = 'l'
-            print(table)
+                lookup_table = resource_utils.get_machine_image_lookup_table([r.region['region_id'] for r in results])
+
+                table = PrettyTable(
+                    ["Server ID", "Region", "Provider ID", "Server Name", "Public IP", "Platform", "Budget",
+                     "Product", "Status", "Start Date", "User", "Arch", "Data Center", "Agent", "Groups",
+                     "Machine Image"])
+                for r in results:
+                    owning_group_ids = None
+                    agent_version = None
+
+                    if hasattr(r, 'public_ip_address'):
+                        public_ip_address = r.public_ip_address
+                    elif hasattr(r, 'public_ip_addresses'):
+                        public_ip_address = ",".join(r.public_ip_addresses)
+                    else:
+                        public_ip_address = None
+
+                    if hasattr(r, 'owning_groups'):
+                        owning_group_ids = ",".join([str(g['group_id']) for g in r.owning_groups])
+
+                    try:
+                        if r.agent_version != 0:
+                            # agent version 0 means not installed
+                            agent_version = r.agent_version
+                    except AttributeError:
+                        pass
+
+                    try:
+                        machine_image_name = lookup_table[str(r.region['region_id'])][
+                            str(r.machine_image['machine_image_id'])]
+                    except KeyError:
+                        machine_image_name = None
+
+                    table.add_row([r.server_id,
+                                   r.region['name'] if hasattr(r.region, 'name') else r.region['region_id'],
+                                   r.provider_id if hasattr(r, 'provider_id') else None,
+                                   r.name if hasattr(r, 'name') else None,
+                                   public_ip_address,
+                                   r.platform if hasattr(r, 'platform') else None,
+                                   r.budget if hasattr(r, 'budget') else None,
+                                   r.provider_product_id if hasattr(r, 'provider_product_id') else None,
+                                   r.status if hasattr(r, 'status') else None,
+                                   r.start_date if hasattr(r, 'start_date') else None,
+                                   r.owning_user['user_id'] if hasattr(r, 'owning_user') else None,
+                                   r.architecture if hasattr(r, 'architecture') else None,
+                                   r.data_center['data_center_id'] if hasattr(r, "data_center") else None,
+                                   agent_version,
+                                   owning_group_ids,
+                                   lookup_table[str(r.region['region_id'])][str(r.machine_image['machine_image_id'])]])
+                table.align = 'l'
+                print(table)
+
+            else:
+                table = PrettyTable(
+                    ["Server ID", "Region", "Provider ID", "Server Name", "Public IP", "Platform", "Budget",
+                     "Product", "Status", "Start Date"])
+                for r in results:
+                    if hasattr(r, 'public_ip_address'):
+                        public_ip_address = r.public_ip_address
+                    elif hasattr(r, 'public_ip_addresses'):
+                        public_ip_address = ",".join(r.public_ip_addresses)
+                    else:
+                        public_ip_address = None
+
+                    table.add_row([r.server_id,
+                                   r.region['name'] if hasattr(r.region, 'name') else r.region['region_id'],
+                                   r.provider_id if hasattr(r, 'provider_id') else None,
+                                   r.name if hasattr(r, 'name') else None,
+                                   public_ip_address,
+                                   r.platform if hasattr(r, 'platform') else None,
+                                   r.budget if hasattr(r, 'budget') else None,
+                                   r.provider_product_id if hasattr(r, 'provider_product_id') else None,
+                                   r.status if hasattr(r, 'status') else None,
+                                   r.start_date if hasattr(r, 'start_date') else None])
+                table.align = 'l'
+                print(table)
         else:
             print "No results found."
 
     if 'DCM_DEBUG' in os.environ:
-        print 'Results returned in', time.time()-start, 'seconds.'
+        print 'Results returned in', time.time() - start, 'seconds.'

--- a/docs/cli_tools/dcm-list-servers.rst
+++ b/docs/cli_tools/dcm-list-servers.rst
@@ -19,27 +19,34 @@ Syntax
 
 .. code-block:: bash
 
-   usage: dcm-list-servers [-h] [--all] [--userid USERID | --email EMAIL]
-                           [--groupid GROUPID | --groupname GROUPNAME]
-                           [--budgetid BUDGETID | --budgetname BUDGETNAME]
-                           [--verbose]
+    usage: dcm-list-servers [-h] [--region REGION] [--extended EXTENDED]
+                            [--verbose] [--userid USERID | --email EMAIL]
+                            [--groupid GROUPID | --groupname GROUPNAME]
+                            [--budgetid BUDGETID | --budgetname BUDGETNAME]
+                            [--json | --xml | --csv]
 
-   optional arguments:
-     -h, --help            show this help message and exit
-     --all, -a             List all servers.
-     --userid USERID, -u USERID
-                           Owning user's VM login ID. For example, p100.
-     --email EMAIL, -m EMAIL
-                           E-Mail address of owning user.
-     --groupid GROUPID, -g GROUPID
-                           Owning group's group ID.
-     --groupname GROUPNAME, -G GROUPNAME
-                           Owning group's group name.
-     --budgetid BUDGETID, -b BUDGETID
-                           Budget ID.
-     --budgetname BUDGETNAME, -B BUDGETNAME
-                           Budget Name.
-     --verbose, -v         Produce verbose output
+    optional arguments:
+      -h, --help            show this help message and exit
+      --region REGION, -r REGION
+                            Region ID
+      --extended EXTENDED, -e EXTENDED
+                            Extended Status
+      --verbose, -v         print more more Server properties in the table
+      --userid USERID, -u USERID
+                            Owning user's VM login ID. For example, p100.
+      --email EMAIL, -m EMAIL
+                            E-Mail address of owning user.
+      --groupid GROUPID, -g GROUPID
+                            Owning group's group ID.
+      --groupname GROUPNAME, -G GROUPNAME
+                            Owning group's group name.
+      --budgetid BUDGETID, -b BUDGETID
+                            Budget ID.
+      --budgetname BUDGETNAME, -B BUDGETNAME
+                            Budget Name.
+      --json                print API response in JSON format.
+      --xml                 print API response in XML format.
+      --csv                 print API response in CSV format.
 
 Options
 ~~~~~~~
@@ -109,7 +116,9 @@ Options
 |                    |                                                              |
 |                    | Example: QA                                                  |
 +--------------------+--------------------------------------------------------------+
-| -v, --verbose      | Print out verbose information while listing servers.         |
+| -v, --verbose      | Print out more information about servers when listing such   |
+|                    | as Machine Image Name, Architecture, Owning User, Owning     |
+|                    | Group etc                                                    |
 +--------------------+--------------------------------------------------------------+
 
 Common Options
@@ -140,10 +149,39 @@ Output
 
 .. code-block:: bash
 
-   +-----------+-----------+-------------+----------------------------+-----------+---------+------------------------------+
-   | Server ID |   Region  | Provider ID |        Server Name         | Public IP |  Status |          Start Date          |
-   +-----------+-----------+-------------+----------------------------+-----------+---------+------------------------------+
-   |    528    | eu-west-1 |  i-e91fde98 |        web server          |    None   | STOPPED | 2014-02-02T23:19:31.000+0000 |
-   |    529    | eu-west-1 |  i-97481137 |        chef server         |    None   | STOPPED | 2014-02-25T07:21:30.000+0000 |
-   |    601    | us-east-1 |  i-83a3fa23 |       puppet server        |    None   | STOPPED | 2014-01-31T07:55:55.000+0000 |
-   +-----------+-----------+-------------+----------------------------+-----------+---------+------------------------------+
+    +-----------+--------+-------------+----------------------+---------------+----------+--------+-----------+---------+------------------------------+
+    | Server ID | Region | Provider ID | Server Name          | Public IP     | Platform | Budget | Product   | Status  | Start Date                   |
+    +-----------+--------+-------------+----------------------+---------------+----------+--------+-----------+---------+------------------------------+
+    | 115626    | 1031   | i-2fb42dfd  | jds-2012-test        | None          | WINDOWS  | 200    | m3.medium | STOPPED | 2015-08-14T14:41:57.000+0000 |
+    | 115642    | 1031   | i-bdd74716  | jds-sensu1           | None          | UBUNTU   | 200    | m1.medium | STOPPED | 2015-08-19T12:40:13.000+0000 |
+    | 226380    | 1031   | i-58c804fa  | jdsiara54            | 22.22.22.21   | UBUNTU   | 200    | m1.medium | RUNNING | 2015-10-07T17:07:27.000+0000 |
+    | 155837    | 1031   | i-4a8028e9  | jdsubu090915-1       | 22.22.22.22   | UBUNTU   | 807    | m1.medium | RUNNING | 2015-09-09T12:21:02.000+0000 |
+    | 155805    | 1034   | i-a21c8362  | appliance-win        | 22.22.22.23   | WINDOWS  | 200    | m3.medium | RUNNING | 2015-09-02T20:03:50.000+0000 |
+    | 85236     | 1034   | i-b8e7a77b  | puppetmaster (keep!) | 22.22.22.24   | CENT_OS  | 200    | m3.medium | RUNNING | 2015-08-14T16:07:55.000+0000 |
+    | 155833    | 1033   | i-bcd59679  | training             | 22.22.22.25   | UBUNTU   | 200    | m1.medium | RUNNING | 2015-09-04T16:51:06.000+0000 |
+    +-----------+--------+-------------+----------------------+---------------+----------+--------+-----------+---------+------------------------------+
+
+
+Example 2
+^^^^^^^^^
+
+.. code-block:: bash
+
+   dcm-list-servers -v
+
+Output
+%%%%%%
+
+.. code-block:: bash
+
+    +-----------+--------+-------------+----------------------+---------------+----------+--------+-----------+---------+------------------------------+------+------+-------------+-------+--------+-----------------------------------------------------------------+
+    | Server ID | Region | Provider ID | Server Name          | Public IP     | Platform | Budget | Product   | Status  | Start Date                   | User | Arch | Data Center | Agent | Groups | Machine Image                                                   |
+    +-----------+--------+-------------+----------------------+---------------+----------+--------+-----------+---------+------------------------------+------+------+-------------+-------+--------+-----------------------------------------------------------------+
+    | 115626    | 1031   | i-2fb42dfd  | jds-2012-test        | None          | WINDOWS  | 200    | m3.medium | STOPPED | 2015-08-14T14:41:57.000+0000 | 3250 | I64  | 1266        | None  | None   | Windows_Server-2012-R2_RTM-English-64Bit-Base-2015.07.15        |
+    | 115642    | 1031   | i-bdd74716  | jds-sensu1           | None          | UBUNTU   | 200    | m1.medium | STOPPED | 2015-08-19T12:40:13.000+0000 | 3250 | I64  | 1265        | None  | 201    | ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-20140416.1   |
+    | 226380    | 1031   | i-58c804fa  | jdsiara54            | 22.22.22.21   | UBUNTU   | 200    | m1.medium | RUNNING | 2015-10-07T17:07:27.000+0000 | 3250 | I64  | 1265        | None  | 201    | ubuntu/images/ebs/ubuntu-precise-12.04-amd64-server-20150204    |
+    | 155837    | 1031   | i-4a8028e9  | jdsubu090915-1       | 22.22.22.22   | UBUNTU   | 807    | m1.medium | RUNNING | 2015-09-09T12:21:02.000+0000 | 3250 | I64  | 1265        | None  | 201    | ubuntu/images/ebs/ubuntu-precise-12.04-amd64-server-20150204    |
+    | 155805    | 1034   | i-a21c8362  | appliance-win        | 22.22.22.23   | WINDOWS  | 200    | m3.medium | RUNNING | 2015-09-02T20:03:50.000+0000 | 900  | I64  | 1274        | None  | None   | Amazon/Windows_Server-2008-R2_SP1-English-64Bit-Base-2015.01.01 |
+    | 85236     | 1034   | i-b8e7a77bc | puppetmaster (keep!) | 22.22.22.24   | CENT_OS  | 200    | m3.medium | RUNNING | 2015-08-14T16:07:55.000+0000 | 1005 | I64  | 1273        | None  | None   | CentOS 6.4 x86_64 - with updates - G2 support                   |
+    | 155833    | 1033   | i-bcd59679  | training             | 22.22.22.25   | UBUNTU   | 200    | m1.medium | RUNNING | 2015-09-04T16:51:06.000+0000 | 900  | I64  | 1271        | 104   | None   | ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-20140416.1   |
+    +-----------+--------+-------------+----------------------+---------------+----------+--------+-----------+---------+------------------------------+------+------+-------------+-------+--------+-----------------------------------------------------------------+

--- a/docs/source/mixcoatl.rst
+++ b/docs/source/mixcoatl.rst
@@ -18,3 +18,4 @@ Mixcoatl
    mixcoatl/resource
    mixcoatl/endpoint
    mixcoatl/utils
+   mixcoatl/resource_utils

--- a/docs/source/mixcoatl/resource_utils.rst
+++ b/docs/source/mixcoatl/resource_utils.rst
@@ -1,0 +1,7 @@
+:mod:`resource_utils`
+------------
+
+.. automodule:: mixcoatl.resource_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/mixcoatl/resource_utils.py
+++ b/mixcoatl/resource_utils.py
@@ -1,16 +1,20 @@
 from mixcoatl.admin.billing_code import BillingCode
 from mixcoatl.geography.region import Region
+from mixcoatl.infrastructure.machine_image import MachineImage
 from mixcoatl.admin.group import Group
 from mixcoatl.admin.user import User
+"""Common utilities for manipulating cloud resources"""
 
 
 def get_servers(servers, **kwargs):
     """ Returns a list of servers
 
     Arguments:
+
     :param servers: a list of servers that needs to be filtered.
 
     Keyword arguments:
+
     :param account_user_id: owning user's account user ID.
     :param vm_login_id: owning user's VM login ID.
     :param email: owning user's email address.
@@ -62,9 +66,11 @@ def get_snapshots(snapshots, **kwargs):
     """ Returns a list of snapshots
 
     Arguments:
+
     :param snapshots: a list of snapshots that needs to be filtered.
 
     Keyword arguments:
+
     :param group_id: owning group's group ID.
     :param budget_id: budget ID.
     :returns: a list of filtered snapshots.
@@ -86,9 +92,11 @@ def get_volumes(volumes, **kwargs):
     """ Returns a list of volumes
 
     Arguments:
+
     :param volumes: a list of volumes that needs to be filtered.
 
     Keyword arguments:
+
     :param vm_login_id: owning user's VM login ID.
     :param email: owning user's email address.
     :param group_id: owning group's group ID.
@@ -135,9 +143,11 @@ def get_user(users, **kwargs):
     """ Returns a user that matches with arguments.
 
     Arguments:
+
     :param users: a list of users that needs to be filtered.
 
     Keyword arguments:
+
     :param vm_login_id: owning user's VM login ID.
     :param email: owning user's email address.
     :returns: a list of filtered users.
@@ -161,6 +171,7 @@ def get_account_user_id(**kwargs):
     """ Returns account_user_id from arguments
 
     Keyword arguments:
+
     :param vm_login_id: user's VM login ID like p100
     :param email: user's E-Mail address
     :returns: account_user_id
@@ -180,6 +191,7 @@ def get_vm_login_id(**kwargs):
     """ Returns vm_login_id from arguments
 
     Keyword arguments:
+
     :param email: user's E-Mail address
     :returns: vm_login_id
     :rtype: str
@@ -195,6 +207,7 @@ def get_budget_id(budget_name):
     """ Returns budget_id from arguments
 
     Arguments:
+
     :param budget_name: budget name
     :returns: budget_id
     :rtype: int
@@ -211,6 +224,7 @@ def get_group_id(group_name):
     """ Returns a group ID from group name
 
     Arguments:
+
     :param group_name: name of the group
     :returns: group_id
     :rtype: int
@@ -227,6 +241,7 @@ def get_region_id(region_pid):
     """ Returns a region ID from provider_id such as us-east-1.
 
     Arguments:
+    
     :param region_pid: provider ID of the region such as us-east-1
     :returns: region_id such as 19343
     :rtype: int
@@ -237,3 +252,40 @@ def get_region_id(region_pid):
         if hasattr(region, 'provider_id') and region.provider_id == region_pid:
             selected_region = region
             return selected_region.region_id
+
+def get_machine_image_lookup_table(region_list):
+    """ Returns a nested dictionary of machine image names keyed with region_id and machine_image_id. As
+
+        .. code-block:: python
+
+            regions = [1031, 1032, 1034]
+            machine_image_id = 50321
+
+            lookup_table = get_machine_image_lookup_table(regions)
+
+            print "VM Image Name:"
+            print lookup_table["1031"][str(machine_image_id)]
+
+    :param region_list: list of regions which you want lookup table composed of
+    :return: dict of dicts containing machine image names
+    """
+    unique_regions = set(region_list)
+    lookup_table = dict((rk, {}) for rk in unique_regions)
+
+    for region in unique_regions:
+        machines = MachineImage.all(region_id=region)
+        for m in MachineImage.all(region_id=region):
+            if str(region) not in lookup_table:
+                lookup_table[str(region)] = {}
+
+            try:
+                machine_image_id = m.machine_image_id
+            except AttributeError:
+                break
+            try:
+                machine_name = m.name
+            except AttributeError:
+                break
+            lookup_table[str(region)][str(machine_image_id)] = m.name
+
+    return lookup_table

--- a/tests/live/test_cli.py
+++ b/tests/live/test_cli.py
@@ -74,6 +74,10 @@ class TestCli:
             "dcm-list-users",
             "dcm-list-volumes"]
 
+        self.simple_flags = [
+            "dcm-list-servers -v"
+        ]
+
     def test_list_cli_simple(self):
         """run dcm-list-* commands that require no flags and work with account keys"""
         failed_commands = []
@@ -114,3 +118,20 @@ class TestCli:
             for command in failed_commands:
                 fail_message = "%s\n%s" % (fail_message, command)
             raise AssertionError(fail_message)
+
+    def test_list_cli_simple_flags(self):
+        """run dcm-list-* commands that require some simple flags and work with account keys"""
+        failed_commands = []
+
+        for command in self.simple_flags:
+            try:
+                assert 0 == subprocess.call(command.split())
+            except AssertionError:
+                failed_commands.append(command)
+
+        if failed_commands:
+            fail_message = "These commands failed"
+            for command in failed_commands:
+                fail_message = "%s\n%s" % (fail_message, command)
+            raise AssertionError(fail_message)
+


### PR DESCRIPTION
Add the -v flag to dcm-list-servers that adds a number of columns to the
table output, including User, Group, Architecture, Data Center, Agent,
and Machine Image name. Add a new resource utility utility for building
a lookup table for machine image names.